### PR TITLE
update basalSchedule for mdt

### DIFF
--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -1404,8 +1404,9 @@ extension MinimedPumpManager: PumpManager {
             do {
                 let newSchedule = BasalSchedule(repeatingScheduleValues: scheduleItems)
                 try session.setBasalSchedule(newSchedule, for: .standard)
-
-
+                self.setState { (state) in
+                    state.basalSchedule = newSchedule
+                }
                 completion(.success(BasalRateSchedule(dailyItems: scheduleItems, timeZone: session.pump.timeZone)!))
             } catch let error {
                 self.log.error("Save basal profile failed: %{public}@", String(describing: error))


### PR DESCRIPTION
With this modification:
* Changing basal rates in Therapy now changes the reported scheduled basal for the Medtronic Pump screen.
* I confirmed that the value in the pump still matches the therapy setting value.

This PR adds self.setState lines and appears to fix the issue. But I do not know enough to know if this is the right fix or if these lines belong in a different place.

## Problem being solved:

See [Loop Issue 2137](https://github.com/LoopKit/Loop/issues/2137) for the problem description.

## Solution Steps:

It was clear that the scheduled basal was being updated for everything except the state needed to display properly in `MinimedKitUI/Views/MinimedPumpSettingsView.swift`. 

I examined the differences between the OmniKit code and the MinimedKit code.

* In `OmniKit/OmniKit/PumpManager/OmnipodPumpManager.swift` there is a setBasalSchedule that is needed for pods, but not for MDT. As part of this function, self.setState is updated with the new schedule.
* In `MinimedKit/PumpManager/MinimedPumpManager.swift`, the save to pump is done differently and I did not find the self.setState lines in the file.


