### PR TITLE
BugFix: Medtronic-TimeChange: guard against bolusInProgress, add clock badge

### DIFF
--- a/MinimedKit/PumpManager/MinimedPumpManager.swift
+++ b/MinimedKit/PumpManager/MinimedPumpManager.swift
@@ -1452,6 +1452,9 @@ extension MinimedPumpManager: PumpManager {
                 guard let session = session else {
                     throw PumpManagerError.connection(MinimedPumpManagerError.noRileyLink)
                 }
+                guard self.state.unfinalizedBolus == nil else {
+                    throw PumpManagerError.configuration(MinimedPumpManagerError.bolusInProgress)
+                }
                 try session.setTimeToNow(in: .current)
                 completion(nil)
             } catch let error {

--- a/MinimedKitUI/MinimedPumpManager+UI.swift
+++ b/MinimedKitUI/MinimedPumpManager+UI.swift
@@ -67,6 +67,24 @@ extension MinimedPumpManager: PumpManagerUI {
     }
 }
 
+    public enum MinimedStatusBadge: DeviceStatusBadge {
+        case timeSyncNeeded
+
+        public var image: UIImage? {
+            switch self {
+            case .timeSyncNeeded:
+                return UIImage(systemName: "clock.fill")
+            }
+        }
+
+        public var state: DeviceStatusBadgeState {
+            switch self {
+            case .timeSyncNeeded:
+                return .warning
+            }
+        }
+    }
+
 // MARK: - PumpStatusIndicator
 extension MinimedPumpManager {
     
@@ -79,6 +97,10 @@ extension MinimedPumpManager {
     }
     
     public var pumpStatusBadge: DeviceStatusBadge? {
-        return nil
+        if isClockOffset {
+            return MinimedStatusBadge.timeSyncNeeded
+        } else {
+            return nil
+        }
     }
 }


### PR DESCRIPTION
This is to protect against the fatal error caused by changing timezone in the middle of a bolus as reported by @dabear.

See [zulipchat discussion](https://loop.zulipchat.com/#narrow/stream/144182-development/topic/Crash.20with.20.20insulindoses.20where.20startDate.20is.20after.20endDate/near/425805651)

While working on that, I noticed the clock icon does not appear on the main Loop screen, so I added that too.