### PR TITLE
Use environment appName instead of hardcoded Loop

### DIFF
--- a/MinimedKit.xcodeproj/project.pbxproj
+++ b/MinimedKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B69083572BCC35A000F26B88 /* Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B69083552BCC359800F26B88 /* Bundle.swift */; };
 		C1229C2229C7ECA70066A89C /* TimeInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1229C2129C7ECA70066A89C /* TimeInterval.swift */; };
 		C1229C2429C7ECEB0066A89C /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1229C2329C7ECEB0066A89C /* Data.swift */; };
 		C13CC33529C7B6A9007F25DE /* LoopKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E34B6729C7AD62009A50A5 /* LoopKit.framework */; };
@@ -352,6 +353,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		B69083552BCC359800F26B88 /* Bundle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		C1229C2129C7ECA70066A89C /* TimeInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeInterval.swift; sourceTree = "<group>"; };
 		C1229C2329C7ECEB0066A89C /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		C13CC34129C7B73A007F25DE /* MinimedKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MinimedKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1184,6 +1186,7 @@
 		C1E34B0929C7ABF2009A50A5 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B69083552BCC359800F26B88 /* Bundle.swift */,
 				C1E34B0A29C7ABF2009A50A5 /* Image.swift */,
 				C1E34B8729C7B292009A50A5 /* Comparable.swift */,
 				C1E34B8B29C7B334009A50A5 /* IdentifiableClass.swift */,
@@ -1726,6 +1729,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C1E34B2829C7ABF3009A50A5 /* MinimedPumpSetupCompleteViewController.swift in Sources */,
+				B69083572BCC35A000F26B88 /* Bundle.swift in Sources */,
 				C1E34B8829C7B292009A50A5 /* Comparable.swift in Sources */,
 				C1E34B8A29C7B2FC009A50A5 /* LocalisedString.swift in Sources */,
 				C1E34B2429C7ABF3009A50A5 /* Image.swift in Sources */,

--- a/MinimedKit/PumpManager/PumpOpsSession.swift
+++ b/MinimedKit/PumpManager/PumpOpsSession.swift
@@ -9,7 +9,7 @@
 import Foundation
 import LoopKit
 import RileyLinkBLEKit
-
+import SwiftUI
 
 public protocol PumpOpsSessionDelegate: AnyObject {
     func pumpOpsSession(_ session: PumpOpsSession, didChange state: PumpState)
@@ -42,11 +42,13 @@ extension SetBolusError: LocalizedError {
     }
 
     public var helpAnchor: String? {
+        // ToDo: convert to @Environment(\.appName)
+        let appName: String = "the app"
         switch self {
         case .certain(let error):
             return error.errorDescription
         case .uncertain:
-            return LocalizedString("Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports.", comment: "Help anchor for uncertain bolus")
+            return String(format: LocalizedString("%1$@ sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, %2$@ will assume the bolus was delivered. When %3$@ eventually fetches history from the pump, and the estimated bolus finish time is passed, %4$@ will update its records of delivery to match what the pump reports.", comment: "Help anchor for uncertain bolus (1: appName) (2: appName) (3: appName) (4: appName)"), appName, appName, appName, appName)
         }
     }
 }

--- a/MinimedKitUI/Extensions/Bundle.swift
+++ b/MinimedKitUI/Extensions/Bundle.swift
@@ -1,0 +1,15 @@
+//
+//  Bundle.swift
+//  MinimedKit
+//
+//  Created by Darin Krauss on 1/23/21.
+//  Copyright © 2021 LoopKit Authors. All rights reserved.
+//
+
+import Foundation
+
+extension Bundle {
+    var bundleDisplayName: String {
+        return object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
+    }
+}

--- a/MinimedKitUI/MinimedPumpUICoordinator.swift
+++ b/MinimedKitUI/MinimedPumpUICoordinator.swift
@@ -141,6 +141,8 @@ class MinimedUICoordinator: UINavigationController, PumpManagerOnboarding, Compl
     }
 
     private func hostingController<Content: View>(rootView: Content) -> DismissibleHostingController<some View> {
+        let rootView = rootView
+            .environment(\.appName, Bundle.main.bundleDisplayName)
         return DismissibleHostingController(content: rootView, colorPalette: colorPalette)
     }
 

--- a/MinimedKitUI/RadioSelectionTableViewController.swift
+++ b/MinimedKitUI/RadioSelectionTableViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import LoopKitUI
 import MinimedKit
+import SwiftUI
 
 
 extension RadioSelectionTableViewController: IdentifiableClass {
@@ -26,21 +27,23 @@ extension RadioSelectionTableViewController: IdentifiableClass {
 
     static func batteryChemistryType(_ value: MinimedKit.BatteryChemistryType) -> T {
         let vc = T()
+        @Environment(\.appName) var appName
 
         vc.selectedIndex = value.rawValue
         vc.options = (0..<2).compactMap({ BatteryChemistryType(rawValue: $0) }).map { String(describing: $0) }
-        vc.contextHelp = LocalizedString("Alkaline and Lithium batteries decay at differing rates. Alkaline tend to have a linear voltage drop over time whereas lithium cell batteries tend to maintain voltage until halfway through their lifespan. Under normal usage in a Non-MySentry compatible Minimed (x22/x15) insulin pump running Loop, Alkaline batteries last approximately 4 to 5 days. Lithium batteries last between 1-2 weeks. This selection will use different battery voltage decay rates for each of the battery chemistry types and alert the user when a battery is approximately 8 to 10 hours from failure.", comment: "Instructions on selecting battery chemistry type")
+        vc.contextHelp = String(format: LocalizedString("Alkaline and Lithium batteries decay at differing rates. Alkaline tend to have a linear voltage drop over time whereas lithium cell batteries tend to maintain voltage until halfway through their lifespan. Under normal usage in a Non-MySentry compatible Minimed (x22/x15) insulin pump running %1$@, Alkaline batteries last approximately 4 to 5 days. Lithium batteries last between 1-2 weeks. This selection will use different battery voltage decay rates for each of the battery chemistry types and alert the user when a battery is approximately 8 to 10 hours from failure.", comment: "Instructions on selecting battery chemistry type (1: appName)"), appName)
 
         return vc
     }
 
     static func useMySentry(_ value: Bool) -> T {
         let vc = T()
+        @Environment(\.appName) var appName
 
         vc.selectedIndex = value ? 0 : 1
             
         vc.options = ["Use MySentry", "Do not use MySentry"]
-        vc.contextHelp = LocalizedString("Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models.", comment: "Instructions on selecting setting for MySentry")
+        vc.contextHelp = String(format: LocalizedString("Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows %1$@ to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models.", comment: "Instructions on selecting setting for MySentry (1: appName)"), appName)
 
         return vc
     }

--- a/MinimedKitUI/Views/UseMySentrySelectionView.swift
+++ b/MinimedKitUI/Views/UseMySentrySelectionView.swift
@@ -11,6 +11,7 @@ import MinimedKit
 import LoopKitUI
 
 struct UseMySentrySelectionView: View {
+    @Environment(\.appName) private var appName
 
     @Binding var mySentryConfig: MySentryConfig
 
@@ -24,7 +25,7 @@ struct UseMySentrySelectionView: View {
                 }
                 .pickerStyle(.inline)
                 Section(content: {}, footer: {
-                    Text(LocalizedString("Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models.", comment: "Instructions on selecting setting for MySentry"))
+                    Text(String(format: LocalizedString("Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows %1$@ to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models.", comment: "Instructions on selecting setting for MySentry (1: appName)"), self.appName))
                 })
             }
         }


### PR DESCRIPTION
1. Add code needed to use environment that ties appName to CFBundleDisplayName
2. Use the appName from the environment to replace hardcoded Loop in strings
   * For one file, I did not know how to insert the environment variable for appName, so I put in a work-around string instead
   * This can be updated if someone provides instructions (`PumpOpsSession.swift`)

None of these changes could be tested.
* I think some of these views just aren't used anymore
* The one that is used requires an MDT with MySentry to test and I only have an MDT