### PR TITLE
Translations, localizable.xcstrings (Multilingual)

### DIFF
--- a/MinimedKit/Resources/Localizable.xcstrings
+++ b/MinimedKit/Resources/Localizable.xcstrings
@@ -1079,8 +1079,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Auto-Off Alarm"
+            "state" : "translated",
+            "value" : "Báo động tự tắt"
           }
         },
         "yy-YY" : {
@@ -1353,8 +1353,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery Depleted"
+            "state" : "translated",
+            "value" : "Pin đã cạn"
           }
         },
         "yy-YY" : {
@@ -1490,8 +1490,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery Out Limit"
+            "state" : "translated",
+            "value" : "Ngưỡng pin yếu"
           }
         },
         "yy-YY" : {
@@ -1627,8 +1627,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "BatteryIssue17"
+            "state" : "translated",
+            "value" : "Sự cố pin 17"
           }
         },
         "yy-YY" : {
@@ -1764,8 +1764,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "BatteryIssue21"
+            "state" : "translated",
+            "value" : "Sự cố pin 21"
           }
         },
         "yy-YY" : {
@@ -2175,8 +2175,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Bolus in Progress"
+            "state" : "translated",
+            "value" : "Đang tiêm bolus"
           }
         },
         "yy-YY" : {
@@ -2312,8 +2312,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Bolus may have failed: %1$@"
+            "state" : "translated",
+            "value" : "Liều Bolus thất bại: %1$@"
           }
         },
         "yy-YY" : {
@@ -2395,7 +2395,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Canada"
           }
         },
@@ -2449,7 +2449,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Canada"
           }
         },
@@ -2723,8 +2723,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Change Basal Profile Schedule"
+            "state" : "translated",
+            "value" : "Thay đổi lịch trình cấu hình Basal"
           }
         },
         "yy-YY" : {
@@ -2860,8 +2860,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Change Basal Schedule"
+            "state" : "translated",
+            "value" : "Thay đổi lịch trình tiêm insulin nền"
           }
         },
         "yy-YY" : {
@@ -3545,8 +3545,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear Alarm"
+            "state" : "translated",
+            "value" : "Xóa báo động"
           }
         },
         "yy-YY" : {
@@ -4250,8 +4250,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device Reset"
+            "state" : "translated",
+            "value" : "Đặt lại thiết bị"
           }
         },
         "yy-YY" : {
@@ -4798,8 +4798,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Glucose page failed crc check"
+            "state" : "translated",
+            "value" : "Trang glucose không vượt qua kiểm tra Crc"
           }
         },
         "yy-YY" : {
@@ -4935,8 +4935,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Go to pump settings and select insulin type"
+            "state" : "translated",
+            "value" : "Vào cài đặt máy bơm và chọn loại insulin"
           }
         },
         "yy-YY" : {
@@ -5072,8 +5072,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "History page does not exist"
+            "state" : "translated",
+            "value" : "Trang lịch sử không tồn tại"
           }
         },
         "yy-YY" : {
@@ -5209,8 +5209,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "History page failed crc check"
+            "state" : "translated",
+            "value" : "Trang lịch sử không vượt qua kiểm tra CRC"
           }
         },
         "yy-YY" : {
@@ -5483,8 +5483,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Type is not configured"
+            "state" : "translated",
+            "value" : "Loại insulin chưa được khai báo"
           }
         },
         "yy-YY" : {
@@ -5894,8 +5894,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
+            "state" : "translated",
+            "value" : "Loop đã gửi lệnh bolus đến máy bơm nhưng không thể xác nhận máy bơm đã nhận lệnh. Vì lý do an toàn, Loop sẽ giả định rằng bolus đã được thực hiện. Khi Loop cuối cùng lấy dữ liệu lịch sử từ máy bơm và thời gian kết thúc bolus ước tính đã qua, Loop sẽ cập nhật hồ sơ giao insulin để khớp với báo cáo từ máy bơm."
           }
         },
         "yy-YY" : {
@@ -6799,7 +6799,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Minimed"
           }
         },
@@ -6853,7 +6853,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Minimed"
           }
         },
@@ -7271,8 +7271,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "New Time"
+            "state" : "translated",
+            "value" : "Thời Gian mới"
           }
         },
         "yy-YY" : {
@@ -7408,8 +7408,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No Delivery Alarm"
+            "state" : "translated",
+            "value" : "Báo động không tiêm insulin"
           }
         },
         "yy-YY" : {
@@ -7545,8 +7545,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No RileyLink Connected"
+            "state" : "translated",
+            "value" : "Không có RileyLink được kết nối"
           }
         },
         "yy-YY" : {
@@ -8093,8 +8093,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Percent Temp Basal"
+            "state" : "translated",
+            "value" : "Phần trăm Basal tạm thời"
           }
         },
         "yy-YY" : {
@@ -8230,8 +8230,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+            "state" : "translated",
+            "value" : "Vui lòng kiểm tra lịch sử bolus trên máy bơm của bạn để xác định xem bolus đã được thực hiện hay chưa."
           }
         },
         "yy-YY" : {
@@ -8367,8 +8367,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Prime"
+            "state" : "translated",
+            "value" : "Mồi bơm"
           }
         },
         "yy-YY" : {
@@ -9059,8 +9059,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump is Suspended"
+            "state" : "translated",
+            "value" : "Bơm đã tạm dừng"
           }
         },
         "yy-YY" : {
@@ -9757,8 +9757,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reprogram Error"
+            "state" : "translated",
+            "value" : "Lỗi tái lập trình bơm"
           }
         },
         "yy-YY" : {
@@ -10168,8 +10168,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Rewind"
+            "state" : "translated",
+            "value" : "Tua lại"
           }
         },
         "yy-YY" : {
@@ -10579,8 +10579,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Select Profile"
+            "state" : "translated",
+            "value" : "Chọn cấu hình"
           }
         },
         "yy-YY" : {
@@ -11538,8 +11538,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unable to store pump data"
+            "state" : "translated",
+            "value" : "Không thể lưu dữ liệu từ bơm"
           }
         },
         "yy-YY" : {
@@ -11675,8 +11675,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unexpected response %1$@"
+            "state" : "translated",
+            "value" : "Phản hồi không mong đợi: %1$@"
           }
         },
         "yy-YY" : {
@@ -11812,8 +11812,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown Alarm"
+            "state" : "translated",
+            "value" : "Báo động không xác định"
           }
         },
         "yy-YY" : {
@@ -11949,8 +11949,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown glucose record type: %$1@"
+            "state" : "translated",
+            "value" : "Loại bản ghi glucose không xác định: %1$@"
           }
         },
         "yy-YY" : {
@@ -12086,8 +12086,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown history record type: %$1@"
+            "state" : "translated",
+            "value" : "Loại bản ghi lịch sử không xác định: %1$@"
           }
         },
         "yy-YY" : {

--- a/MinimedKit/Resources/Localizable.xcstrings
+++ b/MinimedKit/Resources/Localizable.xcstrings
@@ -4,6 +4,12 @@
     "\"%1$@\" has a low battery" : {
       "comment" : "Format string for low battery alert body for RileyLink. (1: device name)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@\" بطارية منخفضة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22,19 +28,37 @@
             "value" : "\"%1$@\" tiene batería baja"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "\"%1$@\" has a low battery"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "\"%1$@\" a un niveau de batterie bas"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "\"%1$@\" has a low battery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "\"%1$@\" has a low battery"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "\"%1$@\" ha la batteria scarica"
+            "value" : "%1$@ ha la batteria quasi scarica"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "\" %1$@ \" har lavt batterinivå"
@@ -52,10 +76,16 @@
             "value" : "„ %1$@ ” ma słabą baterię"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "\"%1$@\" are o baterie scăzută"
+            "state" : "new",
+            "value" : "\"%1$@\" has a low battery"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "\"%1$@\" has a low battery"
           }
         },
         "ru" : {
@@ -64,10 +94,46 @@
             "value" : "\"%1$@\" имеет низкий заряд батареи"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%1$@\" má slabú batériu"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%1$@\" har låg batterinivå"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "\" %1$@ \" pili zayıf"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%1$@\" має низький заряд акумулятора"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "\"%1$@\" gần hết pin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "\"%1$@\" has a low battery"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "\"%1$@\" has a low battery"
           }
         }
       }
@@ -113,7 +179,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ U left"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ U left"
           }
         },
@@ -123,13 +195,7 @@
             "value" : "%1$@ U rimaste"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "残 %1$@単位"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ E igjen"
@@ -147,16 +213,16 @@
             "value" : "%1$@ J pozostało"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U left"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ U restante"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ U rămase"
           }
         },
         "ru" : {
@@ -183,10 +249,22 @@
             "value" : "%1$@ Ü kaldı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U left"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ U còn lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U left"
           }
         },
         "zh-Hans" : {
@@ -238,7 +316,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ U left: %2$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ U left: %2$@"
           }
         },
@@ -248,13 +332,7 @@
             "value" : "%1$@ U rimaste: %2$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "残 %1$@単位: %2$@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ E gjenstår: %2$@"
@@ -272,16 +350,16 @@
             "value" : "%1$@ J pozostało: %2$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U left: %2$@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ U restante: %2$@"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ U rămase: %2$@"
           }
         },
         "ru" : {
@@ -308,10 +386,22 @@
             "value" : "%1$@ Ü kalan: %2$@"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U left: %2$@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ U còn lại: %2$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U left: %2$@"
           }
         },
         "zh-Hans" : {
@@ -325,6 +415,12 @@
     "A bolus is already in progress" : {
       "comment" : "Communications error for a bolus currently running",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هناك جرعة جارية بالفعل"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -357,7 +453,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "A bolus is already in progress"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "A bolus is already in progress"
           }
         },
@@ -367,13 +469,7 @@
             "value" : "Un bolo è già in esecuzione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラス注入中"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "En bolus pågår allerede"
@@ -391,16 +487,16 @@
             "value" : "Podawanie bolusa jest już w toku"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A bolus is already in progress"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Um bolus está em andamento"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Există deja un bolus în curs de administrare"
           }
         },
         "ru" : {
@@ -409,10 +505,16 @@
             "value" : "Болюс уже подается"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podanie bolusu už prebieha"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "En bolusdos ges redan"
+            "value" : "En bolusdos pågår redan"
           }
         },
         "tr" : {
@@ -421,10 +523,22 @@
             "value" : "Bir bolus zaten devam ediyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Болюс вже подається"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liều bolus đang được thực hiện"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A bolus is already in progress"
           }
         },
         "zh-Hans" : {
@@ -438,6 +552,12 @@
     "AlarmClockReminder" : {
       "comment" : "The description of AlarmClockReminderPumpEvent",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تذكير المنبه"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -447,13 +567,13 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AlarmClockReminder"
+            "value" : "Alarm Erinnerung"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AlarmClockReminder"
+            "value" : "Recordatorio de alarma"
           }
         },
         "fi" : {
@@ -465,28 +585,28 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AlarmClockReminder"
+            "value" : "Alarme de rappel"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "AlarmClockReminder"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "AlarmClockReminder"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AlarmClockReminder"
+            "value" : "Promemoria sveglia"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アラームリマインダー"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "PåminnelseAlarmklokke"
@@ -495,12 +615,18 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AlarmClockReminder"
+            "value" : "Wekker herinnering"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "AlarmClockReminder"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "AlarmClockReminder"
           }
         },
@@ -510,16 +636,16 @@
             "value" : "LembreteDeAlarme"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AlarmClockReminder"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Напоминание будильника"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pripomienka budíka"
           }
         },
         "sv" : {
@@ -534,9 +660,21 @@
             "value" : "AlarmSaatiHatırlatma"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нагадування будильника"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "AlarmClockReminder"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "AlarmClockReminder"
           }
         },
@@ -551,10 +689,16 @@
     "AlarmSensor" : {
       "comment" : "The description of AlarmSensorPumpEvent",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تنبيه الحساس"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AlarmSensor"
+            "value" : "Alarm Sensor"
           }
         },
         "de" : {
@@ -566,7 +710,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AlarmSensor"
+            "value" : "Sensor de alarma"
           }
         },
         "fi" : {
@@ -583,23 +727,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "AlarmSensor"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "AlarmSensor"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AlarmSensor"
+            "value" : "Allarme Sensori"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アラームセンサー"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "AlarmSensor"
@@ -608,12 +752,18 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AlarmSensor"
+            "value" : "Alarm sensor"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "AlarmSensor"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "AlarmSensor"
           }
         },
@@ -623,16 +773,16 @@
             "value" : "AlarmeDeSensor"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "AlarmSensor"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Предупреждение от сенсора"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Senzor alarmu"
           }
         },
         "sv" : {
@@ -647,15 +797,27 @@
             "value" : "Alarm Sensörü"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Попередження від сенсора"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "AlarmSensor"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "AlarmSensor"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "AlarmSensor"
           }
         }
@@ -664,6 +826,12 @@
     "Alkaline" : {
       "comment" : "Describing the battery chemistry as Alkaline",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "قلوي"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -696,7 +864,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Alkaline"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Alkaline"
           }
         },
@@ -706,13 +880,7 @@
             "value" : "Alcalina"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アルカリ"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alkalisk"
@@ -730,22 +898,28 @@
             "value" : "Alkaliczna"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Alkaline"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alcalina"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alcalină"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Щелочная"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alkalické"
           }
         },
         "sv" : {
@@ -760,9 +934,21 @@
             "value" : "Alkalin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alkaline"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Alkaline"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Alkaline"
           }
         },
@@ -777,6 +963,12 @@
     "Auto-Off Alarm" : {
       "comment" : "Title for PumpAlarmType.autoOff",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -795,10 +987,28 @@
             "value" : "Alarma de apagado automático"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alarme d'arrêt automatique"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
           }
         },
         "it" : {
@@ -807,7 +1017,7 @@
             "value" : "Allarme spegnimento automatico"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Auto-av alarm"
@@ -825,10 +1035,16 @@
             "value" : "Alarm automatycznego wyłączania"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alarma de oprire automată"
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
           }
         },
         "ru" : {
@@ -837,10 +1053,46 @@
             "value" : "Автоматическое выключение сигнала тревоги"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Auto-av larm"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oto-kapanma alarmı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
           }
         }
       }
@@ -848,6 +1100,12 @@
     "Basal Profile %1$@: %2$@ U/hour" : {
       "comment" : "The format string description of a BasalProfileStartPumpEvent. (1: The index of the profile)(2: The basal rate)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ملف تعريف القاعدي %1$@: %2$@ U/hour"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -880,7 +1138,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Basal Profile %1$@: %2$@ U/hour"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal Profile %1$@: %2$@ U/hour"
           }
         },
@@ -890,13 +1154,7 @@
             "value" : "Profilo basale %1$@: %2$@ U/ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ベーサルプロファイル %1$@: %2$@ U/時"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basalprofil  %1$@: %2$@ E/timen"
@@ -914,22 +1172,28 @@
             "value" : "Profil bazy %1$@: %2$@ J/godzinę"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal Profile %1$@: %2$@ U/hour"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Perfil Basal %1$@: %2$@ U/hora"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Profil bazal %1$@: %2$@ U/oră"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Профиль базала %1$@: %2$@ ед/ч"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bazálny Profil %1$@: %2$@ J/hod"
           }
         },
         "sv" : {
@@ -944,10 +1208,22 @@
             "value" : "Bazal Profili %1$@: %2$@ Ü/saat"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Профіль базалу %1$@: %2$@ U/год"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hồ sơ Basal %1$@: %2$@ U/giờ"
+            "value" : "Hồ sơ liều Basal %1$@: %2$@ U/giờ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal Profile %1$@: %2$@ U/hour"
           }
         },
         "zh-Hans" : {
@@ -961,6 +1237,12 @@
     "Battery Depleted" : {
       "comment" : "Title for PumpAlarmType.batteryDepleted",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -979,10 +1261,28 @@
             "value" : "Batería agotada"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Batterie épuisée"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
           }
         },
         "it" : {
@@ -991,7 +1291,7 @@
             "value" : "Batteria scarica"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Batteriet er tomt"
@@ -1009,10 +1309,16 @@
             "value" : "Bateria wyczerpana"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bateria descărcată"
+            "state" : "new",
+            "value" : "Battery Depleted"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
           }
         },
         "ru" : {
@@ -1021,10 +1327,46 @@
             "value" : "Батарея разряжена"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batteri tömt"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pil Tükenmiş"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
           }
         }
       }
@@ -1032,6 +1374,12 @@
     "Battery Out Limit" : {
       "comment" : "Title for PumpAlarmType.batteryOutLimitExceeded",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1050,19 +1398,37 @@
             "value" : "Alerta de Batería Baja"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limite de sortie de batterie"
           }
         },
-        "it" : {
+        "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Battery Out Limit"
           }
         },
-        "nb" : {
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Grense for batterinivå"
@@ -1080,10 +1446,16 @@
             "value" : "Przekroczono limit wyczerpania baterii"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limită de descărcare a bateriei"
+            "state" : "new",
+            "value" : "Battery Out Limit"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
           }
         },
         "ru" : {
@@ -1092,10 +1464,46 @@
             "value" : "Предел разряда батареи"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gräns för batterinivå"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pil Bitme Sınırı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
           }
         }
       }
@@ -1103,6 +1511,12 @@
     "BatteryIssue17" : {
       "comment" : "Title for PumpAlarmType.deviceResetBatteryIssue17",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1111,7 +1525,7 @@
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "BatteryIssue17"
           }
         },
@@ -1121,19 +1535,37 @@
             "value" : "Problema de bateria 17"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Problème de batterie17"
           }
         },
-        "it" : {
+        "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "BatteryIssue17"
           }
         },
-        "nb" : {
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "BatteriIssue17"
@@ -1151,16 +1583,34 @@
             "value" : "Problem z baterią"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ProblemaBaterie17"
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "BatteryIssue17"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batterifel17"
           }
         },
         "tr" : {
@@ -1168,12 +1618,42 @@
             "state" : "translated",
             "value" : "PilSorunu17"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
         }
       }
     },
     "BatteryIssue21" : {
       "comment" : "Title for PumpAlarmType.deviceResetBatteryIssue21",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1182,7 +1662,7 @@
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "BatteryIssue21"
           }
         },
@@ -1192,19 +1672,37 @@
             "value" : "Problema de bateria 21"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Problème de batterie21"
           }
         },
-        "it" : {
+        "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "BatteryIssue21"
           }
         },
-        "nb" : {
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "BatteriIssue21"
@@ -1222,13 +1720,31 @@
             "value" : "Problem z baterią"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ProblemaBaterie21"
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
           }
         },
         "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "BatteryIssue21"
@@ -1239,6 +1755,30 @@
             "state" : "translated",
             "value" : "PilSorunu21"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
         }
       }
     },
@@ -1248,7 +1788,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "الجرعة"
           }
         },
         "da" : {
@@ -1272,7 +1812,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "Lisäannos"
           }
         },
         "fr" : {
@@ -1283,8 +1823,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bólus"
           }
         },
         "it" : {
@@ -1293,13 +1839,7 @@
             "value" : "Bolo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラス"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus"
@@ -1313,19 +1853,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Bolus"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Bolus"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
           }
         },
@@ -1349,14 +1889,32 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Болюс"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "Liều bolus"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolus Value"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大剂量"
           }
         }
       }
@@ -1364,10 +1922,10 @@
     "Bolus in progress" : {
       "comment" : "Pump error code when bolus is in progress",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Probíhající bolus"
+            "value" : "جرعة قيد التنفيذ"
           }
         },
         "da" : {
@@ -1402,7 +1960,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Bolus in progress"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Bolus in progress"
           }
         },
@@ -1412,13 +1976,7 @@
             "value" : "Bolo in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラスが進行中"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus pågår"
@@ -1436,16 +1994,16 @@
             "value" : "Bolus w toku"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in progress"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus em andamento"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus în derulare"
           }
         },
         "ru" : {
@@ -1472,10 +2030,22 @@
             "value" : "Bolus devam ediyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подання болюса"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liều Bolus đang được thực hiện"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in progress"
           }
         },
         "zh-Hans" : {
@@ -1489,6 +2059,12 @@
     "Bolus in Progress" : {
       "comment" : "Error description when failure due to bolus in progress",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in Progress"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1519,13 +2095,25 @@
             "value" : "Bolus en cours"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in Progress"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in Progress"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolo in corso"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus pågår"
@@ -1543,16 +2131,28 @@
             "value" : "Bolus w toku"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus în curs de administrare"
+            "state" : "new",
+            "value" : "Bolus in Progress"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in Progress"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Подается болюс"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in Progress"
           }
         },
         "sv" : {
@@ -1567,6 +2167,24 @@
             "value" : "Bolus Devam Ediyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in Progress"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in Progress"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in Progress"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1578,6 +2196,12 @@
     "Bolus may have failed: %1$@" : {
       "comment" : "Format string for uncertain bolus. (1: the reported error during bolusing)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1596,10 +2220,28 @@
             "value" : "Es posible que el bolo haya fallado: %1$@"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le bolus a peut-être échoué : %1$@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
           }
         },
         "it" : {
@@ -1608,7 +2250,7 @@
             "value" : "Il bolo potrebbe essere fallito: %1$@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus kan ha mislyktes: %1$@"
@@ -1626,10 +2268,16 @@
             "value" : "Bolus mógł się nie udać: %1$@"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Este posibil ca bolusul să fi eșuat: %1$@"
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
           }
         },
         "ru" : {
@@ -1638,10 +2286,40 @@
             "value" : "Возможно, болюс не прошел: %1$@"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolus kan ha misslyckats: %1$@"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus başarısız olmuş olabilir: %1$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
           }
         },
         "zh-Hans" : {
@@ -1655,9 +2333,15 @@
     "Canada" : {
       "comment" : "Describing the Canada pump region ",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canada"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Canada"
           }
         },
@@ -1681,25 +2365,37 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Canada"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canada"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Canada"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Canada"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Canada"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Canada"
           }
         },
@@ -1709,9 +2405,15 @@
             "value" : "Kanada"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Canada"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Canada"
           }
         },
@@ -1721,10 +2423,16 @@
             "value" : "Канада"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canada"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Canada"
+            "value" : "Kanada"
           }
         },
         "tr" : {
@@ -1732,12 +2440,42 @@
             "state" : "translated",
             "value" : "Kanada"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canada"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canada"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canada"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canada"
+          }
         }
       }
     },
     "Cancel Temp Basal" : {
       "comment" : "Event title for temp basal cancel",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إلغاء الضخ المؤقت للإنسولين القاعدي"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1756,52 +2494,112 @@
             "value" : "Cancelar basal temporal"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Peru väliaikainen Basaali"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annulation du débit basal temporaire"
+            "value" : "Annuler le Basal Temporaire"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel Temp Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Átmeneti Bázis Kikapcsolása"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annulla basale temporanea"
+            "value" : "Cancella basale temporanea"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Avbryt Temp Basal"
+            "value" : "Avbryt manuell basal"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annuleer Tijdelijk Basaal"
+            "value" : "Annuleer tijdelijke basaal"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Anuluj Tymczasową Bazę"
+            "value" : "Anuluj bazę tymczasową"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Anulați bazala temporară"
+            "value" : "Cancelar Basal Temporária"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar Basal Temporária"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Отмена ВБС"
+            "value" : "Отменить ВБС"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zrušiť dočasný bazál"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avbryt temporär basal"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geçici Bazalı İptal Et"
+            "value" : "Geçici Bazali İptal Et"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відмінити Тимчасову Базальну Швидкість (ТБШ)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Huỷ bỏ liều cơ bản tạm thời"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel Temp Basal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消临时基础率"
           }
         }
       }
@@ -1809,10 +2607,10 @@
     "Change Basal Profile Schedule" : {
       "comment" : "Event title for ChangeBasalProfilePatternPumpEvent",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Změnit profil bazálního rozvrhu"
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
           }
         },
         "da" : {
@@ -1833,13 +2631,37 @@
             "value" : "Cambiar programa de perfil basal"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modifica la pianificazione del profilo basale"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Endre basalprofilplan"
@@ -1857,10 +2679,16 @@
             "value" : "Zmień harmonogram profilu podstawowego"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modificarea profilului programului de insulină bazală"
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
           }
         },
         "ru" : {
@@ -1869,10 +2697,46 @@
             "value" : "Смена профиля базала по расписанию"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ändra basalprofilschema"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bazal Profil Programını Değiştir"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
           }
         }
       }
@@ -1880,10 +2744,10 @@
     "Change Basal Schedule" : {
       "comment" : "Event title for ChangeBasalProfilePumpEvent",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Změnit bazální rozvrh"
+            "state" : "new",
+            "value" : "Change Basal Schedule"
           }
         },
         "da" : {
@@ -1904,10 +2768,28 @@
             "value" : "Cambiar programa basal"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Schedule"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modifier le programme basal"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Schedule"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Schedule"
           }
         },
         "it" : {
@@ -1916,7 +2798,7 @@
             "value" : "Modifica il programma della basale"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Endre basal tidsplan"
@@ -1934,10 +2816,16 @@
             "value" : "Zmień schemat bazy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modificarea programului de insulină bazală"
+            "state" : "new",
+            "value" : "Change Basal Schedule"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Schedule"
           }
         },
         "ru" : {
@@ -1946,10 +2834,46 @@
             "value" : "Изменение расписания базала"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Schedule"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ändra basalschema"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bazal Programını Değiştir"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Schedule"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Schedule"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Schedule"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Schedule"
           }
         }
       }
@@ -1995,7 +2919,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Change the pump battery immediately"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Change the pump battery immediately"
           }
         },
@@ -2005,13 +2935,7 @@
             "value" : "Sostituisci immediatamente la batteria della pompa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "すぐにポンプの電池を替えてください"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Skift pumpebatteri umiddelbart"
@@ -2029,16 +2953,16 @@
             "value" : "Natychmiast wymienić baterię pompy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change the pump battery immediately"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Troque a bateria da bomba imediatamente"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schimbați imediat bateria pompei"
           }
         },
         "ru" : {
@@ -2065,10 +2989,22 @@
             "value" : "Pompa pilini hemen değiştirin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change the pump battery immediately"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thay pin máy bơm ngay"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change the pump battery immediately"
           }
         },
         "zh-Hans" : {
@@ -2120,7 +3056,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Change the pump reservoir now"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Change the pump reservoir now"
           }
         },
@@ -2130,13 +3072,7 @@
             "value" : "Cambia ora il serbatoio della pompa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプのレザーバを替えてください"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bytt pumpereservoar nå"
@@ -2154,16 +3090,16 @@
             "value" : "Zmień zbiorniczek w pompie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change the pump reservoir now"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Troque o reservatório da bomba agora"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schimbați rezervorul pompei acum"
           }
         },
         "ru" : {
@@ -2190,10 +3126,22 @@
             "value" : "Pompa rezervuarını şimdi değiştirin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change the pump reservoir now"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thay ngăn chứa insulin bây giờ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change the pump reservoir now"
           }
         },
         "zh-Hans" : {
@@ -2207,10 +3155,10 @@
     "Change Time" : {
       "comment" : "Event title for ChangeTimePumpEvent",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Změnit čas"
+            "state" : "new",
+            "value" : "Change Time"
           }
         },
         "da" : {
@@ -2245,7 +3193,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Change Time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Change Time"
           }
         },
@@ -2255,13 +3209,7 @@
             "value" : "Cambia orario"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "時刻を変更"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Endre tid"
@@ -2279,22 +3227,28 @@
             "value" : "Zmień godzinę"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Time"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mudar Horário"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Schimbare oră"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Смена времени"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Time"
           }
         },
         "sv" : {
@@ -2309,10 +3263,28 @@
             "value" : "Saati Değiştir"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Time"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thay đổi thời gian"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Time"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Time"
           }
         }
       }
@@ -2320,6 +3292,12 @@
     "Check that the pump is not suspended or priming, or has a percent temp basal type" : {
       "comment" : "Suggestions for diagnosing a command refused pump error",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحقق من أن المضخة ليست معلقة أو في وضع التحضير، أو لديها نوع جرعة أساسية مؤقتة بنسبة مئوية"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2329,7 +3307,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Überprüfe, ob die Pumpe nicht unterbrochen wurde oder sich im Füllmodus befindet, oder prozentual temporären Basalraten aktiviert sind"
+            "value" : "Überprüfen Sie, ob die Pumpe nicht unterbrochen wurde oder sich im Füllmodus befindet, oder prozentual temporären Basalraten aktiviert sind"
           }
         },
         "es" : {
@@ -2352,23 +3330,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Check that the pump is not suspended or priming, or has a percent temp basal type"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Check that the pump is not suspended or priming, or has a percent temp basal type"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verifica che la pompa non sia sospesa o in fase di Priming, oppure che abbia un tipo di basale temporaneo percentuale"
+            "value" : "Verificare che il microinfusore non sia sospeso o che sia in caricamento o che abbia impostata una basale in percentuale"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプが停止、プライミング中、または基礎レートが一時的に変更になっていないことを確認してください"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sjekk at pumpa ikke har stoppet tilførsel av insulin, at priming ikke foregår, eller har en  midlertidig prosentbasaltype pågående."
@@ -2377,7 +3355,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Controleer dat de pomp niet is onderbroken of aan het voorbereiden is, of dat er een percentage tijdelijke basaal staat ingesteld"
+            "value" : "Controleer of de pomp niet is onderbroken of aan het voorbereiden is, of dat er een percentage tijdelijke basaal staat ingesteld"
           }
         },
         "pl" : {
@@ -2386,22 +3364,28 @@
             "value" : "Sprawdź, czy pompa nie jest zawieszona, nie trwa wypełnianie lub nie ma ustawionej procentowej dawki tymczasowej w ustawieniach."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check that the pump is not suspended or priming, or has a percent temp basal type"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verifique se a bomba não está suspensa ou em preparação ou tem uma basal temporária percentual"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificați că pompa nu este suspendată sau în curs de inițiere sau ca nu folosește un tip procentual de bazală temporară"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Убедитесь, что помпа не остановлена или не находится в режиме заправки, а так же что ВБС в помпе установлен в Ед/ч, а не в процентах"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skontrolujte že pumpa nie je pozastavená alebo sa nastavuje, alebo má percentuálny dočasný typ bazálu"
           }
         },
         "sv" : {
@@ -2416,10 +3400,22 @@
             "value" : "Pompanın askıya alınmadığını, dolum aşamasında olmadığını veya yüzde geçici bazal tipine sahip olmadığını kontrol edin."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Переконайтеся, що помпа не зупинена або не перебуває в режимі заправки, а так само, що ВБШ в помпі встановлено в U/год, а не у відсотках"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kiểm tra và đảm bảo bơm không tạm ngưng hoặc đang bơm hoặc đang thực hiện liều basal tạm thời"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check that the pump is not suspended or priming, or has a percent temp basal type"
           }
         },
         "zh-Hans" : {
@@ -2433,10 +3429,10 @@
     "Clear Alarm" : {
       "comment" : "Event title for clear alarm pump event",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vymazat alarm"
+            "state" : "new",
+            "value" : "Clear Alarm"
           }
         },
         "da" : {
@@ -2457,13 +3453,37 @@
             "value" : "Borrar alarma"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancella allarme"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fjern alarm"
@@ -2481,10 +3501,16 @@
             "value" : "Wyczyść alarm"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ștergeți alarma"
+            "state" : "new",
+            "value" : "Clear Alarm"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
           }
         },
         "ru" : {
@@ -2493,10 +3519,46 @@
             "value" : "Очистить оповещения"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rensa larm"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alarmı Temizle"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
           }
         }
       }
@@ -2504,6 +3566,12 @@
     "Command refused" : {
       "comment" : "Pump error code returned when command refused",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم رفض الأمر"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2536,23 +3604,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Command refused"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Command refused"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Comando rifiutato"
+            "value" : "Comando negato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "コマンド拒否"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kommando avvist"
@@ -2570,22 +3638,28 @@
             "value" : "Odmowa wykonania polecenia"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Command refused"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Comando recusado"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comandă refuzată"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отказ в выполнении команды"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Príkaz zamietnutý"
           }
         },
         "sv" : {
@@ -2600,10 +3674,22 @@
             "value" : "Komut reddedildi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Команду відхилено"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lệnh bị từ chối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Command refused"
           }
         },
         "zh-Hans" : {
@@ -2617,6 +3703,12 @@
     "Comms with another pump detected" : {
       "comment" : "Description for PumpOpsError.crosstalk",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم اكتشاف الاتصال مع مضخة أخرى."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2655,23 +3747,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Comms with another pump detected."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Comms with another pump detected."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Comunicazione con un altra pompa rilevata."
+            "value" : "Comunicazione con un altro microinfusore rilevata"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "他のポンプが検出"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Oppdaget kommunikasjon med en annen pumpe"
@@ -2689,22 +3781,28 @@
             "value" : "Wykryto połączenie z inną pompą."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Comms with another pump detected."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Comunicação com outra bomba detectada."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "S-a detectat o comunicare cu altă pompă."
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Обнаружена коммуникация с другой помпой"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zaznamenané komunikácie s inou pumpou."
           }
         },
         "sv" : {
@@ -2719,10 +3817,22 @@
             "value" : "Başka bir pompa algılandı."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виявлено комунікацію з іншою помпою"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Comms cho bơm khác được phát hiện."
+            "value" : "Liên lạc cho bơm khác được phát hiện."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Comms with another pump detected."
           }
         },
         "zh-Hans" : {
@@ -2737,10 +3847,16 @@
       "comment" : "Error description",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خطأ في فك التشفير"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Undersøger fejl"
+            "value" : "Afkodningsfejl"
           }
         },
         "de" : {
@@ -2775,7 +3891,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Decoding Error"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Decoding Error"
           }
         },
@@ -2785,13 +3907,7 @@
             "value" : "Errore di decodifica"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "デコーディングエラー"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dekodingsfeil"
@@ -2809,22 +3925,28 @@
             "value" : "Błąd dekodowania"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Decoding Error"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erro de Decodificação"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare la decodare"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ошибка декодирования"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chyba dekódovania"
           }
         },
         "sv" : {
@@ -2839,10 +3961,22 @@
             "value" : "Kod Çözme Hatası"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помилка декодування"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang giải mã bị lỗi"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Decoding Error"
           }
         },
         "zh-Hans" : {
@@ -2857,6 +3991,12 @@
       "comment" : "Error description",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خطأ في الجهاز"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2895,7 +4035,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Device Error"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Device Error"
           }
         },
@@ -2905,13 +4051,7 @@
             "value" : "Errore del dispositivo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "デバイスエラー"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enhetsfeil"
@@ -2929,22 +4069,28 @@
             "value" : "Błąd urządzenia"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Error"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erro no Dispositivo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare dispozitiv"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ошибка устройства"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chyba zariadenia"
           }
         },
         "sv" : {
@@ -2959,10 +4105,22 @@
             "value" : "Cihaz Hatası"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помилка пристрою"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thiết bị lỗi"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Error"
           }
         },
         "zh-Hans" : {
@@ -2976,6 +4134,12 @@
     "Device Reset" : {
       "comment" : "Title for deviceReset",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2994,10 +4158,28 @@
             "value" : "Reinicio del dispositivo"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Réinitialisation de l'appareil"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
           }
         },
         "it" : {
@@ -3006,7 +4188,7 @@
             "value" : "Ripristino del dispositivo"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tilbakestilling av enhet"
@@ -3024,10 +4206,16 @@
             "value" : "Resetowanie urządzenia"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resetare dispozitiv"
+            "state" : "new",
+            "value" : "Device Reset"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
           }
         },
         "ru" : {
@@ -3036,10 +4224,46 @@
             "value" : "Сброс устройства"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Återställ enhet"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cihaz Sıfırlama"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
           }
         }
       }
@@ -3056,85 +4280,91 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afvis"
+            "value" : "Luk"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Schließen"
+            "value" : "Verwerfen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ignorar"
+            "value" : "Descartar"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ohita"
+            "value" : "Hylkää"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fermer"
+            "value" : "Abandonner"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Dismiss"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mégsem"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
+            "value" : "Rimuovi"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "閉じる"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avvis"
+            "value" : "Avskjedige"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sluiten"
+            "value" : "Negeren"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rozumiem"
+            "value" : "Zignoruj"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ignorar"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dispensar"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renunță"
+            "value" : "Ignorar"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отклонить"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zamietnuť"
           }
         },
         "sv" : {
@@ -3149,10 +4379,28 @@
             "value" : "Reddet"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відхилити"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Từ bỏ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dismiss"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "忽略"
           }
         }
       }
@@ -3160,22 +4408,34 @@
     "Empty Reservoir" : {
       "comment" : "Title for PumpAlarmType.emptyReservoir",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الخزان فارغ"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tomt reservoir"
+            "value" : "Tomt Reservoir"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Leeres Reservoir"
+            "value" : "Reservoir leer"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Depósito vacío"
+            "value" : "Reservorio vacío"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty Reservoir"
           }
         },
         "fr" : {
@@ -3184,13 +4444,25 @@
             "value" : "Réservoir vide"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty Reservoir"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty Reservoir"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Serbatoio vuoto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tomt reservoar"
@@ -3199,19 +4471,25 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoir Leeg"
+            "value" : "Reservoir leeg"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pusty zbiorniczek"
+            "state" : "new",
+            "value" : "Empty Reservoir"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rezervor gol"
+            "state" : "new",
+            "value" : "Empty Reservoir"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty Reservoir"
           }
         },
         "ru" : {
@@ -3220,10 +4498,46 @@
             "value" : "Резервуар пуст"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prázdny zásobník"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tom insulinreservoar"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Boş Rezervuar"
+            "value" : "Rezervuar Boş"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Порожній резервуар"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hết thuốc"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty Reservoir"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty Reservoir"
           }
         }
       }
@@ -3231,6 +4545,12 @@
     "Event History" : {
       "comment" : "Describing the pump history insulin data source",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "سجل الأحداث"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3263,23 +4583,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Event History"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Event History"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cronologia degli eventi"
+            "value" : "Storico degli eventi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Event History"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hendelseshistorie"
@@ -3297,22 +4617,28 @@
             "value" : "Historia zdarzeń"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Event History"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Istoric evenimente"
+            "state" : "new",
+            "value" : "Event History"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "История событий"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "História Udalostí"
           }
         },
         "sv" : {
@@ -3327,9 +4653,21 @@
             "value" : "Etkinlik Geçmişi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Журнал подій"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lược sử tác vụ trước đó"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Event History"
           }
         },
@@ -3344,6 +4682,12 @@
     "Glucose page failed crc check" : {
       "comment" : "Error description for glucose page failing crc check",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3374,13 +4718,25 @@
             "value" : "Échec de la vérification CRC de la page de glucose"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "La pagina della glicemia non ha superato il controllo CRC"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Glukoseside mislyktes ved crc-sjekk"
@@ -3398,16 +4754,28 @@
             "value" : "Strona z glukozą nie przeszła kontroli crc."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagina de glicemie nu a reușit verificarea crc"
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Страница глюкозы не прошла проверку crc"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
           }
         },
         "sv" : {
@@ -3421,12 +4789,42 @@
             "state" : "translated",
             "value" : "KŞ sayfası crc kontrolünde başarısız oldu"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
+          }
         }
       }
     },
     "Go to pump settings and select insulin type" : {
       "comment" : "Recovery suggestion for MinimedPumpManagerError.insulinTypeNotConfigured",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3445,10 +4843,28 @@
             "value" : "Vaya a la configuración de la bomba y seleccione el tipo de insulina"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Accédez aux paramètres de la pompe et sélectionnez le type d'insuline"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
           }
         },
         "it" : {
@@ -3457,7 +4873,7 @@
             "value" : "Vai nelle impostazioni della pompa e seleziona il tipo d'insulina"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gå til pumpeinnstillinger og velg insulintype"
@@ -3475,10 +4891,16 @@
             "value" : "Przejdź do ustawień pompy i wybierz typ insuliny"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Accesați setările pompei și selectați tipul de insulină"
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
           }
         },
         "ru" : {
@@ -3487,10 +4909,46 @@
             "value" : "Перейдите в настройки помпы и выберите тип инсулина"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gå till pumpens inställningar och välj insulintyp"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pompa ayarlarına gidin ve insülin tipini seçin"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
           }
         }
       }
@@ -3498,6 +4956,12 @@
     "History page does not exist" : {
       "comment" : "Pump error code when invalid history page is requested",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page does not exist"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3528,13 +4992,25 @@
             "value" : "La page d'historique n'existe pas"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page does not exist"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page does not exist"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "La pagina della cronologia non esiste"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Historie siden eksisterer ikke"
@@ -3552,16 +5028,28 @@
             "value" : "Strona historii nie istnieje"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagina de istoric nu există"
+            "state" : "new",
+            "value" : "History page does not exist"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page does not exist"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Страница истории не существует"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page does not exist"
           }
         },
         "sv" : {
@@ -3575,12 +5063,42 @@
             "state" : "translated",
             "value" : "Geçmiş sayfası mevcut değil"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page does not exist"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page does not exist"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page does not exist"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page does not exist"
+          }
         }
       }
     },
     "History page failed crc check" : {
       "comment" : "Error description for history page failing crc check",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page failed crc check"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3611,13 +5129,25 @@
             "value" : "Échec de la vérification CRC de la page d'historique"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page failed crc check"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page failed crc check"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "La pagina della cronologia non ha superato il controllo CRC"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Historikksiden mislyktes med crc kontroll"
@@ -3635,16 +5165,28 @@
             "value" : "Strona historii nie przeszła kontroli crc."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pagina pentru istoric nu a reușit verificarea crc"
+            "state" : "new",
+            "value" : "History page failed crc check"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page failed crc check"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Страница истории не прошла проверку crc"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page failed crc check"
           }
         },
         "sv" : {
@@ -3658,12 +5200,42 @@
             "state" : "translated",
             "value" : "Geçmiş sayfası crc kontrolünde başarısız oldu"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page failed crc check"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page failed crc check"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page failed crc check"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page failed crc check"
+          }
         }
       }
     },
     "Insulin Suspended" : {
       "comment" : "Status highlight that insulin delivery was suspended.",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3673,19 +5245,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinabgabe unterbrochen"
+            "value" : "Insulin ausgesetzt"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina Suspendida"
+            "value" : "Insulina suspendida"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insuliini pysäytetty"
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         },
         "fr" : {
@@ -3694,52 +5266,100 @@
             "value" : "Insuline suspendue"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erogazione Insulina sospesa"
+            "value" : "Insulina Sospesa"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulintilførsel utsatt"
+            "value" : "Insulintilførsel pauset"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insuline Onderbroken"
+            "value" : "Insuline tijdelijk uitgeschakeld"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podawanie Zawieszone"
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Administrarea insulinei suspendată"
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Подача инсулина приостановлена"
+            "value" : "Подача приостановлена"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inzulín Suspendovaný"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulintillförsel pausad"
+            "value" : "Pump pausad"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İnsülin Askıya Alındı"
+            "value" : "İnsülin Durduldu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подання Припинено"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã tạm dừng cấp liều Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         }
       }
@@ -3747,6 +5367,12 @@
     "Insulin Type is not configured" : {
       "comment" : "Error description for MinimedPumpManagerError.insulinTypeNotConfigured",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3765,10 +5391,28 @@
             "value" : "El tipo de insulina no está configurado"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Type d'insuline"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
           }
         },
         "it" : {
@@ -3777,7 +5421,7 @@
             "value" : "Il tipo d'insulina non è stato configurato"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulintype ikke konfigurert"
@@ -3795,10 +5439,16 @@
             "value" : "Nie skonfigurowano rodzaju insuliny"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipul de insulină nu este configurat"
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
           }
         },
         "ru" : {
@@ -3807,10 +5457,46 @@
             "value" : "Тип инсулина не настроен"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Du måste välja typ av insulin"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "İnsülin Tipi yapılandırılmamış"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
           }
         }
       }
@@ -3818,10 +5504,16 @@
     "Invalid response during %1$@: %2$@" : {
       "comment" : "Format string for failure reason. (1: The operation being performed) (2: The response data)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استجابة غير صحيحة خلال %1$@: %2$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fejlagtigt svar ved %1$@: %2$@"
+            "value" : "Ugyldigt svar under %1$@: %2$@"
           }
         },
         "de" : {
@@ -3850,7 +5542,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Invalid response during %1$@: %2$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Invalid response during %1$@: %2$@"
           }
         },
@@ -3860,13 +5558,7 @@
             "value" : "Risposta non valida per %1$@: %2$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ で反応が無効: %2$@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ugyldig respons ved %1$@: %2$@"
@@ -3884,22 +5576,28 @@
             "value" : "Nieprawidłowa odpowiedź podczas %1$@: %2$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Invalid response during %1$@: %2$@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resposta inválida durante %1$@: %2$@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Răspuns invalid în timpul %1$@: %2$@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неверный отклик %1$@: %2$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neplatná odpoveď počas %1$@: %2$@"
           }
         },
         "sv" : {
@@ -3914,10 +5612,22 @@
             "value" : "%1$@: %2$@ sırasında geçersiz yanıt"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Неправильний відгук %1$@: %2$@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Phản ứng không phù hợp trong khoảng %1$@: %2$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Invalid response during %1$@: %2$@"
           }
         },
         "zh-Hans" : {
@@ -3931,10 +5641,16 @@
     "Lithium" : {
       "comment" : "Describing the battery chemistry as Lithium",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ليثيوم"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lithium"
+            "value" : "Litium"
           }
         },
         "de" : {
@@ -3963,7 +5679,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Lithium"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Lithium"
           }
         },
@@ -3973,16 +5695,10 @@
             "value" : "Litio"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "リチウム"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lithium"
+            "value" : "Litium"
           }
         },
         "nl" : {
@@ -3997,22 +5713,28 @@
             "value" : "Litowa"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lithium"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lítio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Litiu"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Литиевая"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Líthiové"
           }
         },
         "sv" : {
@@ -4027,9 +5749,21 @@
             "value" : "Lityum"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lithium"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lithium"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Lithium"
           }
         },
@@ -4044,6 +5778,12 @@
     "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports." : {
       "comment" : "Help anchor for uncertain bolus",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4062,10 +5802,28 @@
             "value" : "Loop envió una orden de bolo a la bomba, pero no pudo confirmar que la bomba recibiera el comando. Por seguridad, Loop asumirá que el bolo fue administrado. Cuando Loop obtenga finalmente el historial de la bomba, y haya pasado la hora estimada de finalización del bolo, Loop actualizará sus registros de administración para que coincidan con lo que reporta la bomba."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Loop a envoyé une commande de bolus à la pompe, mais n'a pas pu confirmer que la pompe a reçu la commande. Par sécurité, Loop considère que le bolus a été administré. Lorsque Loop récupère l'historique de la pompe, et que l'heure estimée de fin du bolus est dépassée, Loop met à jour ses enregistrements de livraison pour correspondre à ce que la pompe rapporte."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
           }
         },
         "it" : {
@@ -4074,7 +5832,7 @@
             "value" : "Loop ha inviato un comando di bolo alla pompa, ma non è stato in grado di confermare che la pompa lo avesse ricevuto. Per motivi di sicurezza, Loop presumerà che il bolo sia stato effettivamente erogato. Quando Loop recupera la cronologia dalla pompa e l'ora stimata di fine bolo è passata, Loop aggiornerà i propri registri di erogazione in base a quanto riportato dalla pompa."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Loop sendte en boluskommando til pumpen, men kunne ikke bekrefte at pumpen mottok kommandoen. For sikkerhets skyld vil Loop anta at bolusen ble levert. Når Loop til slutt henter historikk fra pumpen, og den estimerte bolussluttiden er passert, vil Loop oppdatere sine leveringsposter for å samsvare med det pumpen rapporterer."
@@ -4092,10 +5850,16 @@
             "value" : "Pętla wysłała polecenie bolusa do pompy, ale nie była w stanie potwierdzić, że pompa odebrała to polecenie. Ze względów bezpieczeństwa Loop założy, że bolus został podany. Gdy Loop w końcu pobierze historię z pompy i minie szacowany czas zakończenia bolusa, Loop zaktualizuje swoją historię podawania, aby była zgodna z raportami pompy."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loop a trimis o comandă de bolus pompei, dar nu a putut confirma că pompa a primit comanda. Pentru siguranță, Loop va presupune că bolusul a fost administrat. Când Loop preia istoricul de la pompă și timpul estimat de terminare a bolusului este trecut, Loop își va actualiza înregistrările de livrare pentru a se potrivi cu ceea ce raportează pompa."
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
           }
         },
         "ru" : {
@@ -4104,10 +5868,40 @@
             "value" : "Loop отправил помпе команду на введение болюса, но не смог подтвердить, что помпа получила эту команду. Для безопасности Loop будет считать, что болюс был доставлен. Когда Loop в конечном итоге получит историю болюсов от помпы и пройдет расчетное время окончания введения болюса, Loop обновит свои записи о болюсах, чтобы они соответствовали данным, полученным от помпы."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loop skickade ett bolus-kommando till pumpen, men kunde inte bekräfta att pumpen fick kommandot. För säkerhets skull kommer Loop anta att bolus levererades. När Loop så småningom hämtar historia från pumpen, och den uppskattade bolus tid passeras, Loop kommer att uppdatera sina register över leverans för att matcha vad pumpen rapporterar."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Loop, pompaya bir bolus komutu gönderdi, ancak pompanın komutu aldığını doğrulayamadı. Güvenlik için, Loop bolusun iletildiğini varsayar. Loop sonunda pompadan geçmişi aldığında ve tahmini bolus bitiş süresi geçtiğinde, Loop iletim kayıtlarını pompanın raporlarıyla eşleşecek şekilde günceller."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
           }
         },
         "zh-Hans" : {
@@ -4121,10 +5915,10 @@
     "Low Battery" : {
       "comment" : "Event title for JournalEntryPumpLowBatteryPumpEvent",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vybitá baterie"
+            "value" : "البطارية منخفضة"
           }
         },
         "da" : {
@@ -4136,7 +5930,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Niedriger Batteriestatus"
+            "value" : "Batterie schwach"
           }
         },
         "es" : {
@@ -4163,19 +5957,19 @@
             "value" : "סוללה חלשה"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Battery"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batteria scarica"
+            "value" : "Batteria Bassa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "電池残量低下"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lavt batterinivå"
@@ -4184,7 +5978,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batterij Bijna Leeg"
+            "value" : "Batterij bijna leeg"
           }
         },
         "pl" : {
@@ -4193,16 +5987,16 @@
             "value" : "Słaba bateria"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Battery"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bateria Fraca"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baterie descărcată"
           }
         },
         "ru" : {
@@ -4229,10 +6023,22 @@
             "value" : "Düşük Pil"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Низький заряд батареї"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "pin yếu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Battery"
           }
         },
         "zh-Hans" : {
@@ -4246,28 +6052,34 @@
     "Low Reservoir" : {
       "comment" : "Event title for JournalEntryPumpLowReservoirPumpEvent",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poloprázdný zásobník"
+            "state" : "new",
+            "value" : "Low Reservoir"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lavt reservoir"
+            "value" : "Lavt Reservoir"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Niedriges Reservoir"
+            "value" : "Niedriger Reservoirstand"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reserva baja"
+            "value" : "Reservorio bajo"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Reservoir"
           }
         },
         "fr" : {
@@ -4276,40 +6088,58 @@
             "value" : "Réservoir bas"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Reservoir"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Reservoir"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Serbatoio scarico"
+            "value" : "Livello serbatoio basso"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lavt reservoar"
+            "value" : "Lite insulin i pod"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoir Bijna Leeg"
+            "value" : "Laag reservoir niveau"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niski poziom w zbiorniczku"
+            "state" : "new",
+            "value" : "Low Reservoir"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rezervor scăzut"
+            "state" : "new",
+            "value" : "Low Reservoir"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Reservoir"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Мало инсулина в резервуаре"
+            "value" : "В резервуаре мало инсулина"
           }
         },
         "sk" : {
@@ -4318,10 +6148,40 @@
             "value" : "Nízka hladina v rezervoári"
           }
         },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Låg reservoarvolym"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Düşük Rezervuar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пустий Резервуар"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sắp hết insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Reservoir"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Reservoir"
           }
         }
       }
@@ -4329,6 +6189,12 @@
     "Low RileyLink Battery" : {
       "comment" : "Title for RileyLink low battery alert",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "بطارية RileyLink منخفضة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4347,10 +6213,28 @@
             "value" : "Batería baja de RileyLink"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low RileyLink Battery"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Batterie RileyLink faible"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low RileyLink Battery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low RileyLink Battery"
           }
         },
         "it" : {
@@ -4359,7 +6243,7 @@
             "value" : "Batteria Rileylink quasi scarica"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lavt RileyLink-batteri"
@@ -4368,7 +6252,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batterij RileyLink Bijna Leeg"
+            "value" : "Batterij RileyLink bijna leeg"
           }
         },
         "pl" : {
@@ -4377,10 +6261,16 @@
             "value" : "Niski poziom baterii RileyLink"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baterie RileyLink scăzută"
+            "state" : "new",
+            "value" : "Low RileyLink Battery"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low RileyLink Battery"
           }
         },
         "ru" : {
@@ -4395,10 +6285,40 @@
             "value" : "Nízky stav batérie RileyLinku"
           }
         },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lågt batteri i RileyLink"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Düşük RileyLink Pili"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Низький заряд RileyLink"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Báo động pin RileyLink thấp"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low RileyLink Battery"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low RileyLink Battery"
           }
         }
       }
@@ -4406,6 +6326,12 @@
     "Make sure your RileyLink is nearby and powered on" : {
       "comment" : "Recovery suggestion",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تأكد من أن RileyLink الخاص بك قريب ويعمل"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4415,7 +6341,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Stelle sicher, dass sich Dein RileyLink in der Nähe befindet und eingeschaltet ist"
+            "value" : "Stellen Sie sicher, dass sich Ihr RileyLink in der Nähe befindet und eingeschaltet ist"
           }
         },
         "es" : {
@@ -4438,23 +6364,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Make sure your RileyLink is nearby and powered on"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Make sure your RileyLink is nearby and powered on"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Assicurati che RileyLink si trovi nelle vicinanze e sia attivato"
+            "value" : "Assicurati che RileyLink si trovi nelle vicinanze e sia acceso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RileyLink が近くにあり電源が入っているか確認"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pass på at din RileyLink er slått på og er i nærheten"
@@ -4463,7 +6389,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zorg ervoor dat je RileyLink dichtbij is en aan staat"
+            "value" : "Zorg ervoor dat je RileyLink dicht bij is en aan staat"
           }
         },
         "pl" : {
@@ -4472,16 +6398,16 @@
             "value" : "Upewnij się, że RileyLink jest w pobliżu i jest włączony"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make sure your RileyLink is nearby and powered on"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verifique se o seu RileyLink está próximo e ligado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Asigurați-vă că RileyLink este pornit și situat în apropriere"
           }
         },
         "ru" : {
@@ -4508,16 +6434,28 @@
             "value" : "RileyLink'inizin yakında olduğundan ve açık olduğundan emin olun"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Впевніться, що RileyLink увімкнений та знаходиться поруч"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đảm bảo RileyLink bên cạnh và đã được bật"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make sure your RileyLink is nearby and powered on"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "请确认Rileylink靠近手机并且已打开"
+            "value" : "确保Rileylink与Pod保持比较近的距离"
           }
         }
       }
@@ -4525,10 +6463,16 @@
     "Max setting exceeded" : {
       "comment" : "Pump error code describing max setting exceeded",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم تجاوز الحد الأقصى للإعدادات"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Max indstilling overskredet"
+            "value" : "Maks. indstilling overskredet"
           }
         },
         "de" : {
@@ -4557,7 +6501,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Max setting exceeded"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Max setting exceeded"
           }
         },
@@ -4567,13 +6517,7 @@
             "value" : "Impostazione massima superata"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定の制限を超えています"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Maksinnstilling overskredet"
@@ -4591,22 +6535,28 @@
             "value" : "Maksymalne ustawienie przekroczone"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Max setting exceeded"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configuração máxima excedida"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setare maximă depășită"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Максимальное значение превышено"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximálne nastavenie prekročené"
           }
         },
         "sv" : {
@@ -4621,10 +6571,22 @@
             "value" : "Maksimum ayar aşıldı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Максимальне значення перевищено"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cài đặt tối đa vượt giới hạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Max setting exceeded"
           }
         },
         "zh-Hans" : {
@@ -4638,10 +6600,10 @@
     "Meal" : {
       "comment" : "Event title for JournalEntryMealMarkerPumpEvent",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jídlo"
+            "state" : "new",
+            "value" : "Meal"
           }
         },
         "da" : {
@@ -4653,13 +6615,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mahlzeit"
+            "value" : "Essen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Comida"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Meal"
           }
         },
         "fr" : {
@@ -4670,8 +6638,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ארוחה"
+            "state" : "new",
+            "value" : "Meal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Meal"
           }
         },
         "it" : {
@@ -4680,7 +6654,7 @@
             "value" : "Pasto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Måltid"
@@ -4694,14 +6668,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Posiłek"
+            "state" : "new",
+            "value" : "Meal"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Masă"
+            "state" : "new",
+            "value" : "Meal"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Meal"
           }
         },
         "ru" : {
@@ -4710,10 +6690,46 @@
             "value" : "Еда"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jedlo"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Måltid"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Öğün"
+            "value" : "Ögün"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Шаблон харчування"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bữa ăn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Meal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Meal"
           }
         }
       }
@@ -4721,39 +6737,135 @@
     "Minimed" : {
       "comment" : "Generic title of the minimed pump manager",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Minimed"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Minimed"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Minimed"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Minimed"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Minimed"
           }
         },
         "ru" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "Minimed"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Minimed"
           }
         }
@@ -4762,6 +6874,12 @@
     "Minimed %@" : {
       "comment" : "Pump title (1: model number)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم تصغير %@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4782,7 +6900,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Minimed %@"
           }
         },
@@ -4794,23 +6912,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Minimed %@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Minimed %@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Minimed %@"
+            "value" : "MiniMed %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minimed %@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimed %@"
@@ -4824,23 +6942,29 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Minimed %@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Minimed %@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Minimed %@"
           }
         },
-        "ro" : {
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimed %@"
           }
         },
-        "ru" : {
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimed %@"
@@ -4858,15 +6982,27 @@
             "value" : "Minimed %@"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimed %@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimed %@"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed %@"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Minimed %@"
           }
         }
@@ -4876,6 +7012,12 @@
       "comment" : "Generic title of the minimed pump manager",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الحد الأدنى 500/700 سلسلة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4914,23 +7056,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Minimed 500/700 Series"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Minimed 500/700 Series"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Minimed serie 500/700"
+            "value" : "MiniMed serie 500/700"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Minimed 500/700 シリーズ"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimed 500/700 series"
@@ -4948,15 +7090,15 @@
             "value" : "Minimed serii 500/700"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Minimed 500/700 Series"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Minimed 500/700 Series"
           }
         },
@@ -4966,13 +7108,25 @@
             "value" : "Minimed 500/700 серий"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ""
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Minimed 500/700 Series"
+            "value" : "Minimed 500/700-serien"
           }
         },
         "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Minimed 500/700 Serisi"
+          }
+        },
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Minimed 500/700 Series"
@@ -4981,6 +7135,12 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Minimed 500/700 Series"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Minimed 500/700 Series"
           }
         },
@@ -4995,10 +7155,10 @@
     "New Time" : {
       "comment" : "Event title for NewTimePumpEvent",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nový čas"
+            "state" : "new",
+            "value" : "New Time"
           }
         },
         "da" : {
@@ -5019,10 +7179,28 @@
             "value" : "Nuevo Tiempo"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Time"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nouvelle heure"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Time"
           }
         },
         "it" : {
@@ -5031,7 +7209,7 @@
             "value" : "Nuovo orario"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ny tid"
@@ -5049,10 +7227,16 @@
             "value" : "Nowy czas"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timp nou"
+            "state" : "new",
+            "value" : "New Time"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Time"
           }
         },
         "ru" : {
@@ -5061,10 +7245,46 @@
             "value" : "Новое время"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Time"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ny tid"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yeni Zaman"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Time"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Time"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Time"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Time"
           }
         }
       }
@@ -5072,6 +7292,12 @@
     "No Delivery Alarm" : {
       "comment" : "Title for PumpAlarmType.noDelivery",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5090,10 +7316,28 @@
             "value" : "No hay alarma de administración de insulina"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alarme: Pas d'administration"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
           }
         },
         "it" : {
@@ -5102,7 +7346,7 @@
             "value" : "Nessun allarme di erogazione"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingen levering alarm"
@@ -5120,10 +7364,16 @@
             "value" : "Alarm! Brak Podawania"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fără alarmă de administrare"
+            "state" : "new",
+            "value" : "No Delivery Alarm"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
           }
         },
         "ru" : {
@@ -5132,10 +7382,46 @@
             "value" : "Нет сигнала тревоги подачи"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inget leveranslarm"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "İletim Alarmı Yok"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
           }
         }
       }
@@ -5143,6 +7429,12 @@
     "No RileyLink Connected" : {
       "comment" : "Error description when no rileylink connected",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No RileyLink Connected"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5173,13 +7465,25 @@
             "value" : "Aucun RileyLink connecté"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No RileyLink Connected"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No RileyLink Connected"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nessun RileyLink connesso"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingen RileyLink tilkoblet"
@@ -5197,16 +7501,28 @@
             "value" : "Brak połączenia z RileyLink"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niciun RileyLink conectat"
+            "state" : "new",
+            "value" : "No RileyLink Connected"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No RileyLink Connected"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не подключен RileyLink"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No RileyLink Connected"
           }
         },
         "sv" : {
@@ -5220,12 +7536,42 @@
             "state" : "translated",
             "value" : "RileyLink Bağlantısı Yok"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No RileyLink Connected"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No RileyLink Connected"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No RileyLink Connected"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No RileyLink Connected"
+          }
         }
       }
     },
     "North America" : {
       "comment" : "Describing the North America pump region",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أمريكا الشماليّة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5258,7 +7604,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "North America"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "North America"
           }
         },
@@ -5268,13 +7620,7 @@
             "value" : "Nord America"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "North America"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nord Amerika"
@@ -5292,22 +7638,28 @@
             "value" : "Ameryka Północna"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "North America"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "América do Norte"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "America de Nord"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сев Америка"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Severná Amerika"
           }
         },
         "sv" : {
@@ -5319,12 +7671,24 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "North America"
+            "value" : "Kuzey Amerika"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Північна Америка"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "North America"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "North America"
           }
         },
@@ -5339,6 +7703,12 @@
     "Ok" : {
       "comment" : "Default alert dismissal",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حسناً"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5354,22 +7724,40 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
+            "value" : "Ok"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ok"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ok"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Ok"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
+            "value" : "Ok"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ok"
@@ -5383,13 +7771,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Ok"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Ok"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Ok"
           }
         },
@@ -5399,10 +7793,46 @@
             "value" : "Ок"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tamam"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ок"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ok"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ok"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ok"
           }
         }
       }
@@ -5413,13 +7843,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "موافق"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+            "value" : "حسناً"
           }
         },
         "da" : {
@@ -5442,7 +7866,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -5454,7 +7878,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -5464,13 +7894,7 @@
             "value" : "OK"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ok"
@@ -5479,31 +7903,31 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ok"
+            "value" : "OK"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "OK"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
+            "value" : "ОК"
           }
         },
         "sk" : {
@@ -5524,16 +7948,28 @@
             "value" : "Tamam"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ОК"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "好的"
+            "value" : "Ok"
           }
         }
       }
@@ -5541,6 +7977,12 @@
     "Percent Temp Basal" : {
       "comment" : "Event title for percent based temp basal",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5559,10 +8001,28 @@
             "value" : "Porcentaje de insulina basal temporal"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pourcentage pour le débit basal temporaire"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
           }
         },
         "it" : {
@@ -5571,7 +8031,7 @@
             "value" : "Percentuale basale temporanea"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prosent midlertidig basal"
@@ -5589,10 +8049,16 @@
             "value" : "Procent Tymczasowej Bazy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Procentul de bazală temporară"
+            "state" : "new",
+            "value" : "Percent Temp Basal"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
           }
         },
         "ru" : {
@@ -5601,10 +8067,46 @@
             "value" : "Проценты временного базала"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Procentuell temp. basal"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geçici Bazal Yüzdesi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
           }
         }
       }
@@ -5612,6 +8114,12 @@
     "Please check your pump bolus history to determine if the bolus was delivered." : {
       "comment" : "recoverySuggestion for uncertain bolus",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5630,10 +8138,28 @@
             "value" : "Por favor compruebe el historial de bolos de su bomba para determinar si se administró la insulina de bolo."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Veuillez vérifier l'historique des bolus de votre pompe pour vérifier si le bolus a été administré."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
           }
         },
         "it" : {
@@ -5642,7 +8168,7 @@
             "value" : "Controlla la cronologia dei boli della pompa per verificare se il bolo è stato erogato."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vennligst kontroller pumpens bolushistorikk for å finne ut om bolusen ble levert."
@@ -5660,10 +8186,16 @@
             "value" : "Sprawdź historię pompy, aby sprawdzić, czy bolus został podany."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vă rugăm să verificați istoricul bolusurilor de pe pompă pentru a determina dacă bolusul a fost administrat."
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
           }
         },
         "ru" : {
@@ -5672,10 +8204,46 @@
             "value" : "Пожалуйста, проверьте историю болюсов в помпе, чтобы определить, был ли болюс доставлен."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontrollera din pumpbolushistorik för att avgöra om bolusen levererades."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolusun iletilip iletilmediğini belirlemek için lütfen pompa bolus geçmişinizi kontrol edin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
           }
         }
       }
@@ -5683,6 +8251,12 @@
     "Prime" : {
       "comment" : "Event title for prime pump event",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5701,21 +8275,39 @@
             "value" : "Purgar"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Purge"
           }
         },
-        "it" : {
+        "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Prime"
           }
         },
-        "nb" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Prime"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Prime"
           }
         },
@@ -5731,10 +8323,16 @@
             "value" : "Główny"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inițiere"
+            "state" : "new",
+            "value" : "Prime"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime"
           }
         },
         "ru" : {
@@ -5743,10 +8341,46 @@
             "value" : "Заполнение"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Förfyll"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hazırlık"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime"
           }
         }
       }
@@ -5792,7 +8426,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump Battery Low"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump Battery Low"
           }
         },
@@ -5802,13 +8442,7 @@
             "value" : "Batteria della pompa scarica"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプの電池が不足"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lavt pumpebatteri"
@@ -5826,22 +8460,28 @@
             "value" : "Niski poziom baterii w pompie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Low"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Batteria da Bomba Fraca"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nivel scăzut baterie pompă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Батарея помпы разряжена"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Low"
           }
         },
         "sv" : {
@@ -5856,10 +8496,22 @@
             "value" : "Pompa Pili Düşük"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Low"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pin của bơm thấp"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Low"
           }
         },
         "zh-Hans" : {
@@ -5873,6 +8525,12 @@
     "Pump did not respond" : {
       "comment" : "Description for PumpOpsError.noResponse",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "المضخة لم تستجب"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5905,23 +8563,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump did not respond"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump did not respond"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La pompa non ha risposto"
+            "value" : "Il microinfusore non risponde"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプが反応しません"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpa svarte ikke"
@@ -5939,22 +8597,28 @@
             "value" : "Pompa nie odpowiada"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump did not respond"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "A bomba não respondeu"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pumpa nu a răspuns"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Помпа не отвечает"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpa neodpovedá"
           }
         },
         "sv" : {
@@ -5969,10 +8633,22 @@
             "value" : "Pompa yanıt vermedi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помпа не відповідає"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bơm không phản hồi"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump did not respond"
           }
         },
         "zh-Hans" : {
@@ -5987,6 +8663,12 @@
       "comment" : "Error description",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خطأ في المضخة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6025,23 +8707,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump Error"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump Error"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Errore pompa"
+            "value" : "Errore microinfusore"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプエラー"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpefeil"
@@ -6050,7 +8732,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pomp Foutmelding"
+            "value" : "Pomp foutmelding"
           }
         },
         "pl" : {
@@ -6059,22 +8741,28 @@
             "value" : "Błąd pompy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Error"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erro na Bomba"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare pompă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ошибка помпы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chyba pumpy"
           }
         },
         "sv" : {
@@ -6089,10 +8777,22 @@
             "value" : "Pompa Hatası"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помилка помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bơm lỗi"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Error"
           }
         },
         "zh-Hans" : {
@@ -6106,6 +8806,12 @@
     "Pump is suspended" : {
       "comment" : "Description for PumpOpsError.pumpSuspended",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تم تعليق المضخة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6138,23 +8844,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump is suspended"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump is suspended"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La pompa è sospesa"
+            "value" : "Il microinfusore è sospeso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプが停止しています"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpe er pauset"
@@ -6172,22 +8878,28 @@
             "value" : "Pompa jest zawieszona"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is suspended"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bomba suspensa"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompa este suspendată"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Помпа остановлена"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpa je pozastavená"
           }
         },
         "sv" : {
@@ -6202,10 +8914,22 @@
             "value" : "Pompa askıya alındı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помпу призупинено"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bơm đang được tạm ngưng"
+            "value" : "Bơm đã tạm dừng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is suspended"
           }
         },
         "zh-Hans" : {
@@ -6219,6 +8943,12 @@
     "Pump is Suspended" : {
       "comment" : "Error description when failure due to pump suspended",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6237,10 +8967,28 @@
             "value" : "La bomba está suspendida"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "La pompe est suspendue"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
           }
         },
         "it" : {
@@ -6249,7 +8997,7 @@
             "value" : "La pompa è sospesa"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpen satt på pause"
@@ -6267,10 +9015,16 @@
             "value" : "Pompa jest zawieszona"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompa este suspendată"
+            "state" : "new",
+            "value" : "Pump is Suspended"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
           }
         },
         "ru" : {
@@ -6279,10 +9033,46 @@
             "value" : "Помпа остановлена"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpen är pausad"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pompa Askıya Alındı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
           }
         }
       }
@@ -6328,7 +9118,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump Reservoir Empty"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump Reservoir Empty"
           }
         },
@@ -6338,13 +9134,7 @@
             "value" : "Serbatoio della pompa vuoto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプのリザーバが空です"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpereservoar Tomt"
@@ -6362,22 +9152,28 @@
             "value" : "Zbiorniczek w pompie jest pusty"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Reservoir Empty"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reservatório da Bomba Vazio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rezervorul pompei este gol"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Резервуар помпы пуст"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Reservoir Empty"
           }
         },
         "sv" : {
@@ -6392,10 +9188,22 @@
             "value" : "Pompa Rezervuarı Boş"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Reservoir Empty"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ngăn chứa hết insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Reservoir Empty"
           }
         },
         "zh-Hans" : {
@@ -6447,7 +9255,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump Reservoir Low"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump Reservoir Low"
           }
         },
@@ -6457,13 +9271,7 @@
             "value" : "Serbatoio della pompa scarico"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプのリザーバが低です"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpereservoar Lavt"
@@ -6481,22 +9289,28 @@
             "value" : "Niski poziom w zbiorniczku pompy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Reservoir Low"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reservatório da Bomba Vazio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rezervor de pompare scăzut"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Мало инсулина в резервуаре"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Reservoir Low"
           }
         },
         "sv" : {
@@ -6511,10 +9325,22 @@
             "value" : "Pompa Rezervuarı Düşük"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Reservoir Low"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ngăn chứa insulin thấp"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Reservoir Low"
           }
         },
         "zh-Hans" : {
@@ -6528,6 +9354,12 @@
     "Pump responded unexpectedly" : {
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "مضخة استجابت بشكل غير متوقع"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6566,23 +9398,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump responded unexpectedly"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump responded unexpectedly"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La pompa ha risposto in modo imprevisto"
+            "value" : "Il microinfusore ha risposto in modo inaspettato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプが不意に反応しました"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpen svarte uventet"
@@ -6600,22 +9432,28 @@
             "value" : "Pompa odpowiedziała w nieoczekiwany sposób"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump responded unexpectedly"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : " Bomba respondeu inesperadamente"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompa a răspuns în mod neașteptat"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неожиданный отклик помпы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpa odpovedala neočakávane"
           }
         },
         "sv" : {
@@ -6630,10 +9468,22 @@
             "value" : "Pompa beklenmedik bir şekilde yanıt verdi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Несподіваний відгук помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bơm phản ứng bất ngờ"
+            "value" : "Bơm phản hồi không như dự kiến"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump responded unexpectedly"
           }
         },
         "zh-Hans" : {
@@ -6648,6 +9498,12 @@
       "comment" : "The format string describing a pump message. (1: The packet type)(2: The message type)(3: The message address)(4: The message data",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رسالة المضخة(%1$@، %2$@، %3$@، %4$@)"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6686,23 +9542,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "PumpMessage(%1$@, %2$@, %3$@, %4$@)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "PumpMessage(%1$@, %2$@, %3$@, %4$@)"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PumpMessage(%1$@, %2$@, %3$@, %4$@)"
+            "value" : "Informazioni pompa(%1$@, %2$@, %3$@, %4$@)"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプメッセージ(%1$@, %2$@, %3$@, %4$@)"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpemelding(%1$@, %2$@, %3$@, %4$@)"
@@ -6711,13 +9567,19 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bericht Pomp (%1$@, %2$@, %3$@, %4$@)"
+            "value" : "Bericht pomp (%1$@, %2$@, %3$@, %4$@)"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wiadomość z pompy (%1$@, %2$@, %3$@, %4$@)"
+            "value" : "Wiadomość od pompy(%1$@, %2$@, %3$@, %4$@)"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "PumpMessage(%1$@, %2$@, %3$@, %4$@)"
           }
         },
         "pt-BR" : {
@@ -6726,16 +9588,16 @@
             "value" : "MensagemDaBomba(%1$@, %2$@, %3$@, %4$@)"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "PumpMessage(%1$@, %2$@, %3$@, %4$@)"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Сообщение помпы(%1$@, %2$@, %3$@, %4$@)"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Správa o pumpe(%1$@, %2$@, %3$@, %4$@)"
           }
         },
         "sv" : {
@@ -6750,9 +9612,21 @@
             "value" : "PompaMesajı(%1$@, %2$@, %3$@, %4$@)"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повідомлення помпи(%1$@, %2$@, %3$@, %4$@)"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "PumpMessage(%1$@, %2$@, %3$@, %4$@)"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "PumpMessage(%1$@, %2$@, %3$@, %4$@)"
           }
         },
@@ -6767,6 +9641,12 @@
     "Reprogram Error" : {
       "comment" : "Title for PumpAlarmType.reprogramError",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6775,7 +9655,7 @@
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Reprogram Error"
           }
         },
@@ -6785,10 +9665,28 @@
             "value" : "Error de reprogramación"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erreur de reprogrammation"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
           }
         },
         "it" : {
@@ -6797,7 +9695,7 @@
             "value" : "Errore di riprogrammazione"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Omprogrammeringsfeil"
@@ -6815,10 +9713,16 @@
             "value" : "Błąd przeprogramowania"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare de reprogramare"
+            "state" : "new",
+            "value" : "Reprogram Error"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
           }
         },
         "ru" : {
@@ -6827,10 +9731,46 @@
             "value" : "Ошибка перепрограммирования"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reprogram Error"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Yeniden Programlama Hatası"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
           }
         }
       }
@@ -6876,7 +9816,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Reservoir"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir"
           }
         },
@@ -6886,13 +9832,7 @@
             "value" : "Serbatoio"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reservoir"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reservoar"
@@ -6910,22 +9850,22 @@
             "value" : "Zbiorniczek"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Reservoir"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rezervor"
+            "state" : "new",
+            "value" : "Reservoir"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoir"
+            "value" : "Резервуар"
           }
         },
         "sk" : {
@@ -6946,16 +9886,28 @@
             "value" : "Rezervuar"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Резервуар"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Ngăn chứa insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "储药器"
+            "value" : "胰岛素容量"
           }
         }
       }
@@ -6963,6 +9915,12 @@
     "Resume" : {
       "comment" : "Event title for resume\nPump Event title for UnfinalizedDose with doseType of .resume",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6981,10 +9939,28 @@
             "value" : "Reanudar"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reprendre"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visszatérés"
           }
         },
         "it" : {
@@ -6993,28 +9969,34 @@
             "value" : "Riprendi"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gjenoppta"
+            "value" : "Gjenoppta leveranse"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hervatten"
+            "value" : "Hervat"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wznowiono"
+            "state" : "new",
+            "value" : "Resume"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reluați"
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
           }
         },
         "ru" : {
@@ -7023,10 +10005,46 @@
             "value" : "Возобновление"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokračovať"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Återuppta"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Devam et"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відновити"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiếp tục"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复"
           }
         }
       }
@@ -7034,6 +10052,12 @@
     "Rewind" : {
       "comment" : "Event title for rewind",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7052,10 +10076,28 @@
             "value" : "Rebobinar"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Retour du piston"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
           }
         },
         "it" : {
@@ -7064,7 +10106,7 @@
             "value" : "Riavvolgi"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Spole tilbake"
@@ -7082,10 +10124,16 @@
             "value" : "Przewiń"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Derulare"
+            "state" : "new",
+            "value" : "Rewind"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
           }
         },
         "ru" : {
@@ -7094,10 +10142,46 @@
             "value" : "Перемотка назад"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Backa"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Geri sarma"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
           }
         }
       }
@@ -7105,10 +10189,16 @@
     "RileyLink radio tune failed" : {
       "comment" : "Error description for tune failure",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "فشل ضبط راديو RileyLink"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "RileyLink radioindstilling fejlede"
+            "value" : "RileyLink-radioindstilling fejlede"
           }
         },
         "de" : {
@@ -7137,7 +10227,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "RileyLink radio tune failed"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "RileyLink radio tune failed"
           }
         },
@@ -7147,13 +10243,7 @@
             "value" : "Sintonizzazione radio RileyLink fallita"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "RileyLink 通信に失敗しました"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "RileyLink radiotuning feilet"
@@ -7162,7 +10252,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afstemmen van de RileyLink Radio mislukt"
+            "value" : "Afstemmen van de RileyLink frequentie mislukt"
           }
         },
         "pl" : {
@@ -7171,16 +10261,16 @@
             "value" : "Dostrajanie radia RileyLink zakończone niepowodzeniem"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "RileyLink radio tune failed"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "A sintonia do rádio RileyLink falhou"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eșec RileyLink la reglarea radio"
           }
         },
         "ru" : {
@@ -7189,10 +10279,16 @@
             "value" : "Настройка радиосвязи с RileyLink не удалась"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RileyLink radio ladenie zlyhalo"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "RileyLink radiosignal misslyckad"
+            "value" : "RileyLinks radiojustering misslyckades"
           }
         },
         "tr" : {
@@ -7201,10 +10297,22 @@
             "value" : "RileyLink ayarı başarısız oldu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування радіозв'язку з RileyLink не вдалося"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "RileyLink radio thất bại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "RileyLink radio tune failed"
           }
         },
         "zh-Hans" : {
@@ -7218,16 +10326,16 @@
     "Scheduled Basal" : {
       "comment" : "Event title for starting scheduled basal",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Plánovaný bazál"
+            "value" : "الجرعة الأساسية المجدولة"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Planlagt basal"
+            "value" : "Planlagt Basal"
           }
         },
         "de" : {
@@ -7239,13 +10347,13 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina basal programada"
+            "value" : "Basal programada"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ohjelmoitu basaali"
+            "state" : "new",
+            "value" : "Scheduled Basal"
           }
         },
         "fr" : {
@@ -7256,7 +10364,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Scheduled Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Scheduled Basal"
           }
         },
@@ -7266,13 +10380,7 @@
             "value" : "Basale programmata"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "定期基礎"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Planlagt basal"
@@ -7281,31 +10389,31 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ingesteld Basaal"
+            "value" : "Gepland basaal"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zaplanowana dawka podstawowa"
+            "state" : "new",
+            "value" : "Scheduled Basal"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scheduled Basal"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basal Agendado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazală programată"
+            "state" : "new",
+            "value" : "Scheduled Basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Запланированная база"
+            "value" : "Запланированный Базал"
           }
         },
         "sk" : {
@@ -7323,7 +10431,13 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Programlanan Bazal"
+            "value" : "Programlanmış Bazal"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запланований Базал"
           }
         },
         "vi" : {
@@ -7331,16 +10445,28 @@
             "state" : "translated",
             "value" : "Đã lên chương trình cho liều Basal"
           }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scheduled Basal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预设基础率"
+          }
         }
       }
     },
     "Select Profile" : {
       "comment" : "Event title for SelectBasalProfilePumpEvent",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vybrat profil"
+            "state" : "new",
+            "value" : "Select Profile"
           }
         },
         "da" : {
@@ -7361,10 +10487,28 @@
             "value" : "Seleccionar perfil"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Profile"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sélectionner un profil"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Profile"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Profile"
           }
         },
         "it" : {
@@ -7373,7 +10517,7 @@
             "value" : "Seleziona profilo"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velg profil"
@@ -7391,10 +10535,16 @@
             "value" : "Wybierz profil"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alegeți profilul"
+            "state" : "new",
+            "value" : "Select Profile"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Profile"
           }
         },
         "ru" : {
@@ -7403,10 +10553,46 @@
             "value" : "Выбор профиля"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Profile"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välj profil"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Profil Seç"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Profile"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Profile"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Profile"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Profile"
           }
         }
       }
@@ -7414,10 +10600,10 @@
     "Signal Loss" : {
       "comment" : "Status highlight when communications with the pod haven't happened recently.",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ztráta signálu"
+            "value" : "فقدان الإشارة"
           }
         },
         "da" : {
@@ -7438,6 +10624,12 @@
             "value" : "Pérdida de señal"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Signal Loss"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7446,20 +10638,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "אובדן אות"
+            "state" : "new",
+            "value" : "Signal Loss"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Signal Loss"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perdita segnale"
+            "value" : "Perdita Di Segnale"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Signal Tap"
+            "value" : "Signaltap"
           }
         },
         "nl" : {
@@ -7470,14 +10668,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utrata sygnału"
+            "state" : "new",
+            "value" : "Signal Loss"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pierdere de semnal"
+            "state" : "new",
+            "value" : "Signal Loss"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Signal Loss"
           }
         },
         "ru" : {
@@ -7492,10 +10696,40 @@
             "value" : "Strata signálu"
           }
         },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signalförlust"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sinyal Kaybı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Втрата сигналу"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mất tín hiệu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Signal Loss"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Signal Loss"
           }
         }
       }
@@ -7503,6 +10737,12 @@
     "Suspend" : {
       "comment" : "Event title for suspend\nPump Event title for UnfinalizedDose with doseType of .suspend",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7521,10 +10761,28 @@
             "value" : "Suspender"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suspendre"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Felfüggesztés"
           }
         },
         "it" : {
@@ -7533,10 +10791,10 @@
             "value" : "Sospendi"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Utsette"
+            "value" : "Pause leveranse"
           }
         },
         "nl" : {
@@ -7547,20 +10805,26 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wstrzymano"
+            "state" : "new",
+            "value" : "Suspend"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspendați"
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Приостановка"
+            "value" : "Остановка"
           }
         },
         "sk" : {
@@ -7569,10 +10833,40 @@
             "value" : "Pozastavenie"
           }
         },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pausa"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Askıya al"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Призупинити"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã tạm dừng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂停"
           }
         }
       }
@@ -7580,10 +10874,16 @@
     "Temp Basal" : {
       "comment" : "Event title for temporary basal rate start\nPump Event title for UnfinalizedDose with doseType of .tempBasal",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Midlertidig basal"
+            "value" : "Midlertidig Basal"
           }
         },
         "de" : {
@@ -7600,14 +10900,26 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilapäinen basaali"
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Débit basal temporaire"
+            "value" : "Basal Temp."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "it" : {
@@ -7616,7 +10928,7 @@
             "value" : "Basale temporanea"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Midlertidig basal"
@@ -7625,25 +10937,31 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tijdelijk Basaal"
+            "value" : "Tijdelijk basaal"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tymczasowa dawka podst."
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazală temporară"
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ВБС"
+            "value" : "Врем. базал"
           }
         },
         "sk" : {
@@ -7661,7 +10979,31 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geçici Bazal"
+            "value" : "Geçici Bazal Oranı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тимчасовий  Базал"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Temp Basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "临时基础率"
           }
         }
       }
@@ -7669,6 +11011,12 @@
     "Temporary Basal: %1$.3f U/hour" : {
       "comment" : "The format string description of a TempBasalPumpEvent. (1: The rate of the temp basal in minutes)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الأساس المؤقت: %1$.3f U/ساعة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7678,7 +11026,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temporäre Basalrate: %1$.3f IE/h"
+            "value" : "Temporäre Basalrate: %1$.3f E/St"
           }
         },
         "es" : {
@@ -7701,7 +11049,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Temporary Basal: %1$.3f U/hour"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Temporary Basal: %1$.3f U/hour"
           }
         },
@@ -7711,13 +11065,7 @@
             "value" : "Basale temporanea: %1$.3f U/ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時基礎レート: %1$.3f U/hour"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Midlertidig basaldose: %1$.3f E/timen"
@@ -7732,7 +11080,13 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Baza tymczasowa: %1$.3f J/godzinę"
+            "value" : "Baza tymczasowa: %1$.3f J/godz"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$.3f U/hour"
           }
         },
         "pt-BR" : {
@@ -7741,16 +11095,16 @@
             "value" : "Basal Temporária: %1$.3f U/hora"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazală temporară: %1$.3f U/oră"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Временный базал: %1$.3f ед/ч"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dočasný Bazál: %1$.3f J/hod"
           }
         },
         "sv" : {
@@ -7765,10 +11119,22 @@
             "value" : "Geçici Bazal: %1$.3f Ü/saat"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тимчасовий базал: %1$.3f U/год"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liều Basal tạm thời: %1$.3f U/giờ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$.3f U/hour"
           }
         },
         "zh-Hans" : {
@@ -7782,10 +11148,10 @@
     "Temporary Basal: %1$d min" : {
       "comment" : "The format string description of a TempBasalDurationPumpEvent. (1: The duration of the temp basal in minutes)",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dočasný bazál: %1$d min"
+            "value" : "الأساس المؤقت: %1$d U/ دقيقة"
           }
         },
         "da" : {
@@ -7824,19 +11190,19 @@
             "value" : "בזאלי זמני: %1$d דקות"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$d min"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basale temporanea: %1$d min"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時基礎レート: %1$d 分"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Midlertidig basaldose: %1$d min"
@@ -7854,22 +11220,28 @@
             "value" : "Baza tymczasowa: %1$d min"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$d min"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basal Temporária: %1$d min"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazală temporară: %1$d min"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Временный базал: %1$d мин"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dočasný Bazál: %1$d min"
           }
         },
         "sv" : {
@@ -7884,10 +11256,22 @@
             "value" : "Geçici Bazal: %1$d dk"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тимчасовий базал: %1$d хв"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liều Basal tạm thời: %1$d phút"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$d min"
           }
         },
         "zh-Hans" : {
@@ -7901,10 +11285,10 @@
     "Temporary Basal: %1$d%%" : {
       "comment" : "The format string description of a TempBasalPumpEvent. (1: The rate of the temp basal in percent)",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dočasný bazál: %1$d%%"
+            "value" : "الأساسي المؤقت: %1$d U/%%"
           }
         },
         "da" : {
@@ -7939,8 +11323,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "בזאלי זמני: %1$d%%"
+            "state" : "new",
+            "value" : "Temporary Basal: %1$d%%"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$d%%"
           }
         },
         "it" : {
@@ -7949,13 +11339,7 @@
             "value" : "Basale temporanea: %1$d%%"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時基礎レート: %1$d%%"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Midlertidig basaldose: %1$d%%"
@@ -7973,22 +11357,28 @@
             "value" : "Baza tymczasowa: %1$d%%"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$d%%"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basal Temporária: %1$d%%"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazală temporară: %1$d%%"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Временный базал: %1$d%%"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dočasný Bazál: %1$d%%"
           }
         },
         "sv" : {
@@ -8003,10 +11393,22 @@
             "value" : "Geçici Bazal: %1$d%%"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тимчасовий базал: %1$d хв%%"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Liều Basal tạm thời: %1$d%%"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$d%%"
           }
         },
         "zh-Hans" : {
@@ -8020,6 +11422,12 @@
     "Unable to store pump data" : {
       "comment" : "Error description when storage fails",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to store pump data"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8050,13 +11458,25 @@
             "value" : "Impossible de stocker les données de la pompe"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to store pump data"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to store pump data"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impossibile memorizzare i dati della pompa"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan ikke lagre pumpedata"
@@ -8074,16 +11494,28 @@
             "value" : "Nie można zapisać danych pompy"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Imposibil de salvat datele pompei"
+            "state" : "new",
+            "value" : "Unable to store pump data"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to store pump data"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Не удается сохранить данные помпы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to store pump data"
           }
         },
         "sv" : {
@@ -8097,12 +11529,42 @@
             "state" : "translated",
             "value" : "Pompa verileri depolanamıyor"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to store pump data"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to store pump data"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to store pump data"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to store pump data"
+          }
         }
       }
     },
     "Unexpected response %1$@" : {
       "comment" : "Format string for an unexpectedResponse. (2: The response)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8121,10 +11583,28 @@
             "value" : "Respuesta inesperada %1$@"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Réponse inattendue %1$@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
           }
         },
         "it" : {
@@ -8133,7 +11613,7 @@
             "value" : "Risposta imprevista %1$@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Uventet svar %1$@"
@@ -8151,10 +11631,16 @@
             "value" : "Nieoczekiwana odpowiedź %1$@"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Răspuns neașteptat %1$@"
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
           }
         },
         "ru" : {
@@ -8163,10 +11649,46 @@
             "value" : "Неожиданный ответ %1$@"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oväntat svar %1$@"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Beklenmeyen yanıt %1$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
           }
         }
       }
@@ -8174,6 +11696,12 @@
     "Unknown Alarm" : {
       "comment" : "Title for PumpAlarmType.unknownType",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8192,10 +11720,28 @@
             "value" : "Alarma desconocida"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alarme inconnue"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
           }
         },
         "it" : {
@@ -8204,7 +11750,7 @@
             "value" : "Allarme sconosciuto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukjent alarm"
@@ -8222,10 +11768,16 @@
             "value" : "Nieznany Alarm"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alarmă necunoscută"
+            "state" : "new",
+            "value" : "Unknown Alarm"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
           }
         },
         "ru" : {
@@ -8234,10 +11786,46 @@
             "value" : "Неизвестный сигнал тревоги"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Okänt larm"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bilinmeyen Alarm"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
           }
         }
       }
@@ -8245,6 +11833,12 @@
     "Unknown glucose record type: %$1@" : {
       "comment" : "Format string for error description for an unknown record type in a glucose page. (1: event type number)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8275,13 +11869,25 @@
             "value" : "Type de glycémie inconnu : %$1@"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tipo di record glicemico sconosciuto: %$1@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukjent glukose registrering: %$1@"
@@ -8299,16 +11905,28 @@
             "value" : "Nieznany typ zapisu glukozy: %$1 @"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tip necunoscut de înregistrare glicemie: %$1@"
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неизвестный тип записи глюкозы: %$1@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
           }
         },
         "sv" : {
@@ -8322,12 +11940,42 @@
             "state" : "translated",
             "value" : "Bilinmeyen KŞ kayıt türü: %$1@"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
+          }
         }
       }
     },
     "Unknown history record type: %$1@" : {
       "comment" : "Format string for error description for an unknown record type in a history page. (1: event type number)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8358,13 +12006,25 @@
             "value" : "Type d'historique inconnu : %$1@"
           }
         },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tipo di record storico sconosciuto: %$1@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukjent historieopptakstype: %$1@"
@@ -8382,16 +12042,28 @@
             "value" : "Nieznany typ zapisu historii: %$1@"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tip necunoscut de înregistrare istoric: %$1@"
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неизвестный тип записи истории: %$1@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
           }
         },
         "sv" : {
@@ -8405,16 +12077,46 @@
             "state" : "translated",
             "value" : "Bilinmeyen geçmiş kayıt türü: %$1 @"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
+          }
         }
       }
     },
     "Unknown pump error code: %1$@" : {
       "comment" : "The format string description of an unknown pump error code. (1: The specific error code raw value)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "رمز خطأ مضخة غير معروف: %1$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ukendt pumpe-fejlkode: %1$@"
+            "value" : "Ukendt pumpefejlkode: %1$@"
           }
         },
         "de" : {
@@ -8443,23 +12145,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Unknown pump error code: %1$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unknown pump error code: %1$@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Codice di errore della pompa sconosciuto: %1$@"
+            "value" : "Codice errore microinfusore sconosciuto: %1$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプエラーコード 不明: %1$@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukjent feilkode fra pumpe: %1$@"
@@ -8477,22 +12179,28 @@
             "value" : "Nieznany kod błędu pompy: %1$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown pump error code: %1$@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Código de erro da bomba desconhecido: %1$@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cod de eroare pompă necunoscut: %1$@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неизвестный код ошибки помпы: %1$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neznáma chyba pumpy kód: %1$@"
           }
         },
         "sv" : {
@@ -8507,10 +12215,22 @@
             "value" : "Bilinmeyen pompa hata kodu:%1$@"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невідомий код помилки помпи: %1$@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Không xác định lỗi của bơm: %1$@"
+            "value" : "Mã lỗi bơm không xác định: %1$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown pump error code: %1$@"
           }
         },
         "zh-Hans" : {
@@ -8523,10 +12243,16 @@
     },
     "Unknown pump model: %@" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نَموذج مضخة غير معروف: %@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ukendt pumpemodel %@"
+            "value" : "Ukendt pumpemodel: %@"
           }
         },
         "de" : {
@@ -8555,23 +12281,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Unknown pump model: %@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unknown pump model: %@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Modello di pompa sconosciuto: %@"
+            "value" : "Modello di microinfusore sconosciuto: %@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプモデル 不明: %@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukjent pumpemodell: %@"
@@ -8589,22 +12315,28 @@
             "value" : "Nieznany model pompy: %@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown pump model: %@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modelo de bomba desconhecido: %@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model de pompă necunoscut: %@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неизвестная модель помпы: %@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neznámy model pumpy: %@"
           }
         },
         "sv" : {
@@ -8619,10 +12351,22 @@
             "value" : "Bilinmeyen pompa modeli: %@"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невідома модель помпи: %@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Không xác định mẫu bơm: %@"
+            "value" : "Không xác định được loại bơm %@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown pump model: %@"
           }
         },
         "zh-Hans" : {
@@ -8636,6 +12380,12 @@
     "Unknown response during %1$@: %2$@" : {
       "comment" : "Format string for an unknown response. (1: The operation being performed) (2: The response data)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "استجابة غير صحيحة خلال %1$@: %2$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8668,7 +12418,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Unknown response during %1$@: %2$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unknown response during %1$@: %2$@"
           }
         },
@@ -8678,13 +12434,7 @@
             "value" : "Risposta sconosciuta per %1$@: %2$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "反応が不明 %1$@: %2$@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukjent respons ved %1$@: %2$@"
@@ -8702,22 +12452,28 @@
             "value" : "Nieoczekiwana odpowiedź podczas %1$@: %2$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown response during %1$@: %2$@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Resposta desconhecida durante %1$@: %2$@"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Răspuns nerecunoscut în timpul %1$@: %2$@"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Неизвестный отклик %1$@: %2$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neznáma odpoveď počas %1$@: %2$@"
           }
         },
         "sv" : {
@@ -8732,10 +12488,22 @@
             "value" : "%1$@: %2$@ sırasında bilinmeyen yanıt"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невідомий відгук %1$@: %2$@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Phản hồi không xác định trong %1$@: %2$@"
+            "value" : "Phản hồi không xác định trong lúc %1$@: %2$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown response during %1$@: %2$@"
           }
         },
         "zh-Hans" : {
@@ -8749,10 +12517,16 @@
     "World-Wide" : {
       "comment" : "Describing the worldwide pump region",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "عالمي"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "World-Wide"
+            "value" : "Globalt"
           }
         },
         "de" : {
@@ -8781,7 +12555,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "World-Wide"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "World-Wide"
           }
         },
@@ -8791,16 +12571,10 @@
             "value" : "Internazionale"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "World-Wide"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "World-Wide"
+            "value" : "Verdensomspennende"
           }
         },
         "nl" : {
@@ -8815,22 +12589,28 @@
             "value" : "Ogólnoświatowa"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "World-Wide"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mundial"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Global"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Глобальный"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Celo-Svetovo"
           }
         },
         "sv" : {
@@ -8842,12 +12622,24 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Dünya Çapında"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "World-Wide"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "World-Wide"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "World-Wide"
           }
         },

--- a/MinimedKit/Resources/Localizable.xcstrings
+++ b/MinimedKit/Resources/Localizable.xcstrings
@@ -10,6 +10,12 @@
             "value" : "%1$@\" بطارية منخفضة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "\"%1$@\" has a low battery"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -147,6 +153,12 @@
             "value" : "%1$@ وحدة متبقية"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U left"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -251,8 +263,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ U left"
+            "state" : "translated",
+            "value" : "%1$@ U залишилося"
           }
         },
         "vi" : {
@@ -282,6 +294,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ وحدة متبقية: %2$@"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ U left: %2$@"
           }
         },
         "da" : {
@@ -388,8 +406,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ U left: %2$@"
+            "state" : "translated",
+            "value" : "%1$@ U залишилось: %2$@"
           }
         },
         "vi" : {
@@ -419,6 +437,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "هناك جرعة جارية بالفعل"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "A bolus is already in progress"
           }
         },
         "da" : {
@@ -558,6 +582,12 @@
             "value" : "تذكير المنبه"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "AlarmClockReminder"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -693,6 +723,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تنبيه الحساس"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "AlarmSensor"
           }
         },
         "da" : {
@@ -832,6 +868,12 @@
             "value" : "قلوي"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Alkaline"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -969,6 +1011,12 @@
             "value" : "Auto-Off Alarm"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Auto-Off Alarm"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1073,8 +1121,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Auto-Off Alarm"
+            "state" : "translated",
+            "value" : "Авто-відключення сигналу"
           }
         },
         "vi" : {
@@ -1104,6 +1152,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ملف تعريف القاعدي %1$@: %2$@ U/hour"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Basal Profile %1$@: %2$@ U/hour"
           }
         },
         "da" : {
@@ -1243,6 +1297,12 @@
             "value" : "Battery Depleted"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Depleted"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1347,8 +1407,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery Depleted"
+            "state" : "translated",
+            "value" : "Розряджена батарея"
           }
         },
         "vi" : {
@@ -1375,6 +1435,12 @@
       "comment" : "Title for PumpAlarmType.batteryOutLimitExceeded",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Out Limit"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Battery Out Limit"
@@ -1484,8 +1550,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery Out Limit"
+            "state" : "translated",
+            "value" : "Ліміт розряду батареї"
           }
         },
         "vi" : {
@@ -1512,6 +1578,12 @@
       "comment" : "Title for PumpAlarmType.deviceResetBatteryIssue17",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue17"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "BatteryIssue17"
@@ -1621,8 +1693,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "BatteryIssue17"
+            "state" : "translated",
+            "value" : "Проблема з батареєю 17"
           }
         },
         "vi" : {
@@ -1649,6 +1721,12 @@
       "comment" : "Title for PumpAlarmType.deviceResetBatteryIssue21",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "BatteryIssue21"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "BatteryIssue21"
@@ -1758,8 +1836,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "BatteryIssue21"
+            "state" : "translated",
+            "value" : "Проблема з батареєю 21"
           }
         },
         "vi" : {
@@ -1789,6 +1867,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الجرعة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus"
           }
         },
         "da" : {
@@ -1928,6 +2012,12 @@
             "value" : "جرعة قيد التنفيذ"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in progress"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2065,6 +2155,12 @@
             "value" : "Bolus in Progress"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus in Progress"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2169,8 +2265,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Bolus in Progress"
+            "state" : "translated",
+            "value" : "Болюс триває"
           }
         },
         "vi" : {
@@ -2197,6 +2293,12 @@
       "comment" : "Format string for uncertain bolus. (1: the reported error during bolusing)",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolus may have failed: %1$@"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Bolus may have failed: %1$@"
@@ -2306,8 +2408,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Bolus may have failed: %1$@"
+            "state" : "translated",
+            "value" : "Можливо, болюс не вдався: %1$@"
           }
         },
         "vi" : {
@@ -2334,6 +2436,12 @@
       "comment" : "Describing the Canada pump region ",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canada"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Canada"
@@ -2443,8 +2551,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Canada"
+            "state" : "translated",
+            "value" : "Канада"
           }
         },
         "vi" : {
@@ -2474,6 +2582,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إلغاء الضخ المؤقت للإنسولين القاعدي"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel Temp Basal"
           }
         },
         "da" : {
@@ -2613,6 +2727,12 @@
             "value" : "Change Basal Profile Schedule"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Profile Schedule"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2717,8 +2837,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Change Basal Profile Schedule"
+            "state" : "translated",
+            "value" : "Зміна розкладу базального профілю"
           }
         },
         "vi" : {
@@ -2745,6 +2865,12 @@
       "comment" : "Event title for ChangeBasalProfilePumpEvent",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Basal Schedule"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Change Basal Schedule"
@@ -2854,8 +2980,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Change Basal Schedule"
+            "state" : "translated",
+            "value" : "Зміна базального графіка"
           }
         },
         "vi" : {
@@ -2885,6 +3011,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "قم بتغيير بطارية المضخة على الفور"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change the pump battery immediately"
           }
         },
         "da" : {
@@ -2991,8 +3123,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Change the pump battery immediately"
+            "state" : "translated",
+            "value" : "Негайно замініть батарейку помпи"
           }
         },
         "vi" : {
@@ -3022,6 +3154,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "قم بتغيير خزان المضخة الآن"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change the pump reservoir now"
           }
         },
         "da" : {
@@ -3128,8 +3266,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Change the pump reservoir now"
+            "state" : "translated",
+            "value" : "Замініть резервуар насоса зараз"
           }
         },
         "vi" : {
@@ -3156,6 +3294,12 @@
       "comment" : "Event title for ChangeTimePumpEvent",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Change Time"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Change Time"
@@ -3265,8 +3409,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Change Time"
+            "state" : "translated",
+            "value" : "Змінити час"
           }
         },
         "vi" : {
@@ -3296,6 +3440,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تحقق من أن المضخة ليست معلقة أو في وضع التحضير، أو لديها نوع جرعة أساسية مؤقتة بنسبة مئوية"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Check that the pump is not suspended or priming, or has a percent temp basal type"
           }
         },
         "da" : {
@@ -3435,6 +3585,12 @@
             "value" : "Clear Alarm"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Clear Alarm"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3539,8 +3695,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Clear Alarm"
+            "state" : "translated",
+            "value" : "Очистити сигнал тривоги"
           }
         },
         "vi" : {
@@ -3570,6 +3726,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تم رفض الأمر"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Command refused"
           }
         },
         "da" : {
@@ -3707,6 +3869,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تم اكتشاف الاتصال مع مضخة أخرى."
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Comms with another pump detected."
           }
         },
         "da" : {
@@ -3853,6 +4021,12 @@
             "value" : "خطأ في فك التشفير"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Decoding Error"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3995,6 +4169,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "خطأ في الجهاز"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Error"
           }
         },
         "da" : {
@@ -4140,6 +4320,12 @@
             "value" : "Device Reset"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device Reset"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4244,8 +4430,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device Reset"
+            "state" : "translated",
+            "value" : "Скидання налаштувань пристрою"
           }
         },
         "vi" : {
@@ -4275,6 +4461,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تجاهل"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Dismiss"
           }
         },
         "da" : {
@@ -4414,6 +4606,12 @@
             "value" : "الخزان فارغ"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty Reservoir"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4549,6 +4747,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "سجل الأحداث"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Event History"
           }
         },
         "da" : {
@@ -4688,6 +4892,12 @@
             "value" : "Glucose page failed crc check"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Glucose page failed crc check"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4792,8 +5002,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Glucose page failed crc check"
+            "state" : "translated",
+            "value" : "Сторінка глюкози не пройшла перевірку CRC"
           }
         },
         "vi" : {
@@ -4820,6 +5030,12 @@
       "comment" : "Recovery suggestion for MinimedPumpManagerError.insulinTypeNotConfigured",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Go to pump settings and select insulin type"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Go to pump settings and select insulin type"
@@ -4929,8 +5145,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Go to pump settings and select insulin type"
+            "state" : "translated",
+            "value" : "Перейдіть до налаштувань помпи та виберіть тип інсуліну"
           }
         },
         "vi" : {
@@ -4957,6 +5173,12 @@
       "comment" : "Pump error code when invalid history page is requested",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page does not exist"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "History page does not exist"
@@ -5066,8 +5288,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "History page does not exist"
+            "state" : "translated",
+            "value" : "Сторінка історії не існує"
           }
         },
         "vi" : {
@@ -5094,6 +5316,12 @@
       "comment" : "Error description for history page failing crc check",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "History page failed crc check"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "History page failed crc check"
@@ -5203,8 +5431,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "History page failed crc check"
+            "state" : "translated",
+            "value" : "Сторінка історії не пройшла перевірку CRC"
           }
         },
         "vi" : {
@@ -5231,6 +5459,12 @@
       "comment" : "Status highlight that insulin delivery was suspended.",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Insulin Suspended"
@@ -5373,6 +5607,12 @@
             "value" : "Insulin Type is not configured"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type is not configured"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5477,8 +5717,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Type is not configured"
+            "state" : "translated",
+            "value" : "Тип інсуліну не налаштовано"
           }
         },
         "vi" : {
@@ -5508,6 +5748,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "استجابة غير صحيحة خلال %1$@: %2$@"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Invalid response during %1$@: %2$@"
           }
         },
         "da" : {
@@ -5647,6 +5893,12 @@
             "value" : "ليثيوم"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Lithium"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5784,6 +6036,12 @@
             "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5888,8 +6146,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Loop sent a bolus command to the pump, but was unable to confirm that the pump received the command. For safety, Loop will assume the bolus was delivered. When Loop eventually fetches history from the pump, and the estimated bolus finish time is passed, Loop will update its records of delivery to match what the pump reports."
+            "state" : "translated",
+            "value" : "Петля надіслав команду болюса на помпу, але не зміг підтвердити, що помпа отримала команду. З міркувань безпеки Петля вважатиме, що болюс було подано. Коли Петля врешті-решт отримає історію з помпи, і приблизний час завершення болюса мине то Петля оновить свої записи про подачу, щоб вони відповідали звітам помпи."
           }
         },
         "vi" : {
@@ -5919,6 +6177,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "البطارية منخفضة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Battery"
           }
         },
         "da" : {
@@ -6053,6 +6317,12 @@
       "comment" : "Event title for JournalEntryPumpLowReservoirPumpEvent",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low Reservoir"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Low Reservoir"
@@ -6195,6 +6465,12 @@
             "value" : "بطارية RileyLink منخفضة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Low RileyLink Battery"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6330,6 +6606,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تأكد من أن RileyLink الخاص بك قريب ويعمل"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Make sure your RileyLink is nearby and powered on"
           }
         },
         "da" : {
@@ -6469,6 +6751,12 @@
             "value" : "تم تجاوز الحد الأقصى للإعدادات"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Max setting exceeded"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6601,6 +6889,12 @@
       "comment" : "Event title for JournalEntryMealMarkerPumpEvent",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Meal"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Meal"
@@ -6743,6 +7037,12 @@
             "value" : "Minimed"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -6847,7 +7147,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Minimed"
           }
         },
@@ -6878,6 +7178,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تم تصغير %@"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed %@"
           }
         },
         "da" : {
@@ -7016,6 +7322,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الحد الأدنى 500/700 سلسلة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Minimed 500/700 Series"
           }
         },
         "da" : {
@@ -7161,6 +7473,12 @@
             "value" : "New Time"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "New Time"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7265,8 +7583,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "New Time"
+            "state" : "translated",
+            "value" : "Новий час"
           }
         },
         "vi" : {
@@ -7293,6 +7611,12 @@
       "comment" : "Title for PumpAlarmType.noDelivery",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Delivery Alarm"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No Delivery Alarm"
@@ -7402,8 +7726,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No Delivery Alarm"
+            "state" : "translated",
+            "value" : "Сигналізація відсутня"
           }
         },
         "vi" : {
@@ -7430,6 +7754,12 @@
       "comment" : "Error description when no rileylink connected",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No RileyLink Connected"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "No RileyLink Connected"
@@ -7539,8 +7869,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No RileyLink Connected"
+            "state" : "translated",
+            "value" : "RileyLink не підключено"
           }
         },
         "vi" : {
@@ -7570,6 +7900,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "أمريكا الشماليّة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "North America"
           }
         },
         "da" : {
@@ -7709,6 +8045,12 @@
             "value" : "حسناً"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Ok"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7844,6 +8186,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "حسناً"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
           }
         },
         "da" : {
@@ -7983,6 +8331,12 @@
             "value" : "Percent Temp Basal"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Percent Temp Basal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8087,8 +8441,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Percent Temp Basal"
+            "state" : "translated",
+            "value" : "Відсоток Тимчасової Базальної Швидкості (ТБШ)"
           }
         },
         "vi" : {
@@ -8115,6 +8469,12 @@
       "comment" : "recoverySuggestion for uncertain bolus",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Please check your pump bolus history to determine if the bolus was delivered."
@@ -8224,8 +8584,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Please check your pump bolus history to determine if the bolus was delivered."
+            "state" : "translated",
+            "value" : "Будь ласка, перевірте історію болюсів вашої помпи, щоб визначити, чи було введено болюс."
           }
         },
         "vi" : {
@@ -8252,6 +8612,12 @@
       "comment" : "Event title for prime pump event",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Prime"
@@ -8361,8 +8727,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Prime"
+            "state" : "translated",
+            "value" : "Прайм\n"
           }
         },
         "vi" : {
@@ -8392,6 +8758,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "بطارية المضخة منخفضة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Low"
           }
         },
         "da" : {
@@ -8498,8 +8870,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump Battery Low"
+            "state" : "translated",
+            "value" : "Низький рівень заряду батареї помпи"
           }
         },
         "vi" : {
@@ -8529,6 +8901,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "المضخة لم تستجب"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump did not respond"
           }
         },
         "da" : {
@@ -8667,6 +9045,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "خطأ في المضخة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Error"
           }
         },
         "da" : {
@@ -8812,6 +9196,12 @@
             "value" : "تم تعليق المضخة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is suspended"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8949,6 +9339,12 @@
             "value" : "Pump is Suspended"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is Suspended"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9053,8 +9449,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump is Suspended"
+            "state" : "translated",
+            "value" : "Помпу призупинено"
           }
         },
         "vi" : {
@@ -9084,6 +9480,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "خزان المضخة منتهي"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Reservoir Empty"
           }
         },
         "da" : {
@@ -9190,8 +9592,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump Reservoir Empty"
+            "state" : "translated",
+            "value" : "Резервуар помпи порожній"
           }
         },
         "vi" : {
@@ -9221,6 +9623,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "خزان المضخة منخفض"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Reservoir Low"
           }
         },
         "da" : {
@@ -9327,8 +9735,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump Reservoir Low"
+            "state" : "translated",
+            "value" : "Низький рівень у резервуара помпи"
           }
         },
         "vi" : {
@@ -9358,6 +9766,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "مضخة استجابت بشكل غير متوقع"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump responded unexpectedly"
           }
         },
         "da" : {
@@ -9504,6 +9918,12 @@
             "value" : "رسالة المضخة(%1$@، %2$@، %3$@، %4$@)"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "PumpMessage(%1$@, %2$@, %3$@, %4$@)"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9647,6 +10067,12 @@
             "value" : "Reprogram Error"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reprogram Error"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9751,8 +10177,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reprogram Error"
+            "state" : "translated",
+            "value" : "Помилка перепрограмування"
           }
         },
         "vi" : {
@@ -9782,6 +10208,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الخزان"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reservoir"
           }
         },
         "da" : {
@@ -9916,6 +10348,12 @@
       "comment" : "Event title for resume\nPump Event title for UnfinalizedDose with doseType of .resume",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Resume"
@@ -10058,6 +10496,12 @@
             "value" : "Rewind"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Rewind"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10162,8 +10606,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Rewind"
+            "state" : "translated",
+            "value" : "Перемотування назад"
           }
         },
         "vi" : {
@@ -10193,6 +10637,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "فشل ضبط راديو RileyLink"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "RileyLink radio tune failed"
           }
         },
         "da" : {
@@ -10332,6 +10782,12 @@
             "value" : "الجرعة الأساسية المجدولة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scheduled Basal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10469,6 +10925,12 @@
             "value" : "Select Profile"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select Profile"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10573,8 +11035,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Select Profile"
+            "state" : "translated",
+            "value" : "Вибір профілю"
           }
         },
         "vi" : {
@@ -10604,6 +11066,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "فقدان الإشارة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Signal Loss"
           }
         },
         "da" : {
@@ -10738,6 +11206,12 @@
       "comment" : "Event title for suspend\nPump Event title for UnfinalizedDose with doseType of .suspend",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Suspend"
@@ -10880,6 +11354,12 @@
             "value" : "Temp Basal"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11015,6 +11495,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الأساس المؤقت: %1$.3f U/ساعة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$.3f U/hour"
           }
         },
         "da" : {
@@ -11154,6 +11640,12 @@
             "value" : "الأساس المؤقت: %1$d U/ دقيقة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$d min"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11289,6 +11781,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الأساسي المؤقت: %1$d U/%%"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temporary Basal: %1$d%%"
           }
         },
         "da" : {
@@ -11428,6 +11926,12 @@
             "value" : "Unable to store pump data"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unable to store pump data"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11532,8 +12036,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unable to store pump data"
+            "state" : "translated",
+            "value" : "Не вдалося зберегти дані помпи"
           }
         },
         "vi" : {
@@ -11560,6 +12064,12 @@
       "comment" : "Format string for an unexpectedResponse. (2: The response)",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unexpected response %1$@"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unexpected response %1$@"
@@ -11669,8 +12179,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unexpected response %1$@"
+            "state" : "translated",
+            "value" : "Неочікувана відповідь %1$@"
           }
         },
         "vi" : {
@@ -11697,6 +12207,12 @@
       "comment" : "Title for PumpAlarmType.unknownType",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown Alarm"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unknown Alarm"
@@ -11806,8 +12322,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown Alarm"
+            "state" : "translated",
+            "value" : "Невідомий сигнал тривого"
           }
         },
         "vi" : {
@@ -11834,6 +12350,12 @@
       "comment" : "Format string for error description for an unknown record type in a glucose page. (1: event type number)",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown glucose record type: %$1@"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unknown glucose record type: %$1@"
@@ -11943,8 +12465,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown glucose record type: %$1@"
+            "state" : "translated",
+            "value" : "Невідомий тип запису глюкози: %$1@"
           }
         },
         "vi" : {
@@ -11971,6 +12493,12 @@
       "comment" : "Format string for error description for an unknown record type in a history page. (1: event type number)",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown history record type: %$1@"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unknown history record type: %$1@"
@@ -12080,8 +12608,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown history record type: %$1@"
+            "state" : "translated",
+            "value" : "Невідомий тип запису історії: %$1@"
           }
         },
         "vi" : {
@@ -12111,6 +12639,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "رمز خطأ مضخة غير معروف: %1$@"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown pump error code: %1$@"
           }
         },
         "da" : {
@@ -12247,6 +12781,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نَموذج مضخة غير معروف: %@"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown pump model: %@"
           }
         },
         "da" : {
@@ -12386,6 +12926,12 @@
             "value" : "استجابة غير صحيحة خلال %1$@: %2$@"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown response during %1$@: %2$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12521,6 +13067,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "عالمي"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "World-Wide"
           }
         },
         "da" : {

--- a/MinimedKitUI/Resources/Localizable.xcstrings
+++ b/MinimedKitUI/Resources/Localizable.xcstrings
@@ -669,7 +669,7 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ Số unit insulin còn lại\n"
+            "value" : "%1$@ Số đơn vị insulin còn lại\n"
           }
         },
         "yy-YY" : {
@@ -1489,8 +1489,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery Chemistry"
+            "state" : "translated",
+            "value" : "Loại pin"
           }
         },
         "yy-YY" : {
@@ -4639,8 +4639,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin\nSuspended"
+            "state" : "translated",
+            "value" : "Insulin\n Đã tạm ngưng"
           }
         },
         "yy-YY" : {
@@ -6009,8 +6009,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
+            "state" : "translated",
+            "value" : "Trên máy bơm của bạn, hãy đi tới \"Find Device\". \n\nChọn Main Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
         "yy-YY" : {

--- a/MinimedKitUI/Resources/Localizable.xcstrings
+++ b/MinimedKitUI/Resources/Localizable.xcstrings
@@ -4,10 +4,10 @@
     "%@ dB" : {
       "comment" : "Unit format string for an RSSI value in decibles",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@ dB"
+            "value" : "%@ ديسيبل"
           }
         },
         "da" : {
@@ -30,7 +30,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@ dB"
           }
         },
@@ -42,7 +42,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@ dB"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@ dB"
           }
         },
@@ -52,7 +58,7 @@
             "value" : "%@ dB"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ dB"
@@ -66,13 +72,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@ dB"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@ dB"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@ dB"
           }
         },
@@ -96,7 +108,31 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ dB"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
+            "value" : "%@ dB"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ dB"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ dB"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@ dB"
           }
         }
@@ -105,6 +141,12 @@
     "%@U" : {
       "comment" : "Format string for reservoir volume. (1: The localized volume)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -137,7 +179,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@U"
           }
         },
@@ -147,13 +195,7 @@
             "value" : "%@U"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@U"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@E"
@@ -171,15 +213,15 @@
             "value" : "%@J"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@U"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%@U"
           }
         },
@@ -207,9 +249,27 @@
             "value" : "%@Ü"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@U"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "%@U"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%@U"
           }
         }
@@ -218,6 +278,12 @@
     "%1$@  %2$@/%3$@  %4$@" : {
       "comment" : "The format string for displaying a frequency tune trial. Extra spaces added for emphesis: (1: frequency in MHz)(2: success count)(3: total count)(4: average RSSI)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@  %2$@/%3$@  %4$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -238,7 +304,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@  %2$@/%3$@  %4$@"
           }
         },
@@ -250,7 +316,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@  %2$@/%3$@  %4$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@  %2$@/%3$@  %4$@"
           }
         },
@@ -260,13 +332,7 @@
             "value" : "%1$@  %2$@/%3$@  %4$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@  %2$@/%3$@  %4$@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@  %2$@/%3$@  %4$@"
@@ -280,23 +346,29 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@  %2$@/%3$@  %4$@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@  %2$@/%3$@  %4$@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@  %2$@/%3$@  %4$@"
           }
         },
-        "ro" : {
+        "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@  %2$@/%3$@  %4$@"
           }
         },
-        "ru" : {
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@  %2$@/%3$@  %4$@"
@@ -314,15 +386,27 @@
             "value" : "%1$@  %2$@/%3$@  %4$@"
           }
         },
-        "vi" : {
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@  %2$@/%3$@  %4$@"
           }
         },
-        "zh-Hans" : {
+        "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "%1$@ %2$@/%3$@ %4$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@  %2$@/%3$@  %4$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@  %2$@/%3$@  %4$@"
           }
         }
@@ -331,6 +415,12 @@
     "%1$@ basal schedule entries\n" : {
       "comment" : "The format string describing number of basal schedule entries: (1: number of entries)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ basal schedule entries\n"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -363,7 +453,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ basal schedule entries\n"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ basal schedule entries\n"
           }
         },
@@ -373,13 +469,7 @@
             "value" : "%1$@ voci del programma basale \n"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎パターン入力 %1$@回\n\n"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ basalsprofilinnslag"
@@ -397,22 +487,28 @@
             "value" : "%1$@ wpisów dawki podstawowej\n"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ basal schedule entries\n"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ entradas de basal programadas\n"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ intervale de insulină bazală\n"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ записи базального расписания\n"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ basal schedule entries\n"
           }
         },
         "sv" : {
@@ -427,10 +523,22 @@
             "value" : "%1$@ bazal girişleri programla\n"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ basal schedule entries\n"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ Lịch biểu liều nền\n"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ basal schedule entries\n"
           }
         },
         "zh-Hans" : {
@@ -444,6 +552,12 @@
     "%1$@ Units of insulin remaining\n" : {
       "comment" : "The format string describing units of insulin remaining: (1: number of units)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ Units of insulin remaining\n"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -476,7 +590,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ Units of insulin remaining\n"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ Units of insulin remaining\n"
           }
         },
@@ -486,13 +606,7 @@
             "value" : "%1$@ Unità d'insulina rimanenti\n"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリン 残り%1$@U\n\n"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gjenstående %1$@ Enheter med insulin"
@@ -510,22 +624,28 @@
             "value" : "%1$@ jednostek insuliny pozostało\n"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ Units of insulin remaining\n"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ Unidades de insulina restantes\n"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ Unități de insulină rămase\n"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ Осталось единиц инсулина\n"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ Units of insulin remaining\n"
           }
         },
         "sv" : {
@@ -540,10 +660,22 @@
             "value" : "%1$@ Ünite kalan insülin\n"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ Units of insulin remaining\n"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ Số unit insulin còn lại\n"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ Units of insulin remaining\n"
           }
         },
         "zh-Hans" : {
@@ -557,6 +689,12 @@
     "%1$@ units remaining at %2$@" : {
       "comment" : "Accessibility format string for (1: localized volume)(2: time)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -589,23 +727,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@ units remaining at %2$@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@ unità rimanenti a %2$@"
+            "value" : "%1$@ unità rimanenti alle ore %2$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%2$@の時点で %1$@ U 残っています"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ enheter gjenstår ved %2$@"
@@ -623,16 +761,16 @@
             "value" : "%1$@ jednostek pozostaje w %2$@"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ unidades restantes em %2$@"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ unități rămase la %2$@"
           }
         },
         "ru" : {
@@ -659,10 +797,28 @@
             "value" : "%1$@ ünite kaldı %2$@"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ одиниць залишилося на %2$@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ units vẫn đang còn lúc %2$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
           }
         }
       }
@@ -670,55 +826,61 @@
     "%1$@%2$@%3$@" : {
       "comment" : "String format for value with units (1: value, 2: separator, 3: units)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
+            "value" : "%1$@ %2$@ %3$@"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ %2$@ %3$@"
@@ -726,31 +888,31 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
@@ -762,25 +924,37 @@
         },
         "sv" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "%1$@%2$@%3$@"
           }
         }
@@ -789,6 +963,12 @@
     "Adjusting Pump Time..." : {
       "comment" : "Text indicating ongoing pump time synchronization",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "جاري ضبط وقت المضخة..."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -798,55 +978,73 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pumpenzeit einstellen"
+            "value" : "Pumpenzeit anpassen..."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ajustando la hora de la bomba..."
+            "value" : "Ajustando hora de la bomba..."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjusting Pump Time..."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ajustement de l'horloge de la pompe..."
+            "value" : "Ajustement de l'heure de la pompe..."
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מתאם את שעת המשאבה..."
+            "state" : "new",
+            "value" : "Adjusting Pump Time..."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjusting Pump Time..."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Regolazione orario pompa in corso..."
+            "value" : "Regolando Tempo microinfusore..."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Justerer pumpetid..."
+            "value" : "Juster pumpe-tid..."
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pomptijd Aanpassen..."
+            "value" : "Pomptijd aanpassen..."
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synchronizacja czasu pompy..."
+            "state" : "new",
+            "value" : "Adjusting Pump Time..."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reglarea timpului pompei..."
+            "state" : "new",
+            "value" : "Adjusting Pump Time..."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjusting Pump Time..."
           }
         },
         "ru" : {
@@ -855,16 +1053,46 @@
             "value" : "Настройка времени помпы..."
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nastavenie času pumpy..."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Justerar pumptid..."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pompa Zamanı Ayarlanıyor..."
+            "value" : "Pompa Zamanını Ayarlama..."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування Часу Помпи..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang điều chỉnh thời gian của bơm..."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjusting Pump Time..."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "调整泵时间..."
+            "state" : "new",
+            "value" : "Adjusting Pump Time..."
           }
         }
       }
@@ -872,10 +1100,16 @@
     "Alkaline and Lithium batteries decay at differing rates. Alkaline tend to have a linear voltage drop over time whereas lithium cell batteries tend to maintain voltage until halfway through their lifespan. Under normal usage in a Non-MySentry compatible Minimed (x22/x15) insulin pump running Loop, Alkaline batteries last approximately 4 to 5 days. Lithium batteries last between 1-2 weeks. This selection will use different battery voltage decay rates for each of the battery chemistry types and alert the user when a battery is approximately 8 to 10 hours from failure." : {
       "comment" : "Instructions on selecting battery chemistry type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "البطاريات القلوية والبطاريات الليثيومية تتحلل بمعدلات مختلفة. عادةً ما يكون للبطاريات القلوية انخفاض تدريجي ومستمر في الجهد الكهربائي مع مرور الوقت، بينما تحافظ بطاريات الليثيوم على الجهد الكهربائي حتى تصل إلى منتصف عمرها الافتراضي. في مضخات الأنسولين من طراز Minimed (x22/x15) غير المتوافقة مع MySentry والتي تعمل بنظام Loop، تدوم البطاريات القلوية لمدة تتراوح بين 4 إلى 5 أيام تقريبًا تحت الاستخدام العادي. بينما تدوم بطاريات الليثيوم من أسبوع إلى أسبوعين. سيقوم هذا الاختيار باستخدام معدلات تحلل الجهد المختلفة لكل نوع من أنواع البطاريات وينبه المستخدم عندما تكون البطارية على وشك النفاد، أي قبل حوالي 8 إلى 10 ساعات من الفشل."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alkaline og Lithium batterier henfalder med forskellige hastigheder. Alkaline har tendens til at have et lineært fald over tid, hvor Lithium batteri celler typisk opretholder deres spænding indtil halvejen i deres levetid. Ved normalt brug i en ikke-MySentry kompatibel Minimed (x22/x15) insulinpumpe, som kører Loop, vil alkalinebatterier holde cirka 4 til 5 dage. Lithium batterier holder mellem 1 til 2 uger. Denne indstilling bruger forskellige batteri henfaldssatser for hver kemiske batteritype og alarmerer brugeren, når et batteri er cirka 8 til 10 timer fra at løbe tør."
+            "value" : "Alkaline- og Lithium-batterier har forskellige henfaldstider. Alkaline har typisk et lineært fald over tid, hvorimod Lithium-battericeller typisk bibeholder deres spænding indtil halvvejs i deres levetid. Ved normalt brug i en ikke-MySentry kompatibel Minimed (x22/x15) insulinpumpe, der kører Sløjfe, vil alkaliske batterier holde cirka 4 til 5 dage. Lithium-batterier holder fra 1 til 2 uger. Denne indstilling bruger forskellige batterispændingshenfaldstider for hver af de batterikemiske typer og alarmerer brugeren, når et batteri er ca. 8 til 10 timer fra at løbe tørt."
           }
         },
         "de" : {
@@ -904,23 +1138,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Alkaline and Lithium batteries decay at differing rates. Alkaline tend to have a linear voltage drop over time whereas lithium cell batteries tend to maintain voltage until halfway through their lifespan. Under normal usage in a Non-MySentry compatible Minimed (x22/x15) insulin pump running Loop, Alkaline batteries last approximately 4 to 5 days. Lithium batteries last between 1-2 weeks. This selection will use different battery voltage decay rates for each of the battery chemistry types and alert the user when a battery is approximately 8 to 10 hours from failure."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Alkaline and Lithium batteries decay at differing rates. Alkaline tend to have a linear voltage drop over time whereas lithium cell batteries tend to maintain voltage until halfway through their lifespan. Under normal usage in a Non-MySentry compatible Minimed (x22/x15) insulin pump running Loop, Alkaline batteries last approximately 4 to 5 days. Lithium batteries last between 1-2 weeks. This selection will use different battery voltage decay rates for each of the battery chemistry types and alert the user when a battery is approximately 8 to 10 hours from failure."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le batterie alcaline e al litio decadono a velocità diverse. Le batterie alcaline tendono ad avere una caduta di tensione lineare nel tempo mentre le batterie al litio tendono a mantenere la tensione fino a metà della loro durata. In condizioni di utilizzo normali con in esecuzione Loop, in una pompa d'insulina non compatibile con MySentry (x22/x15), le batterie alcaline durano dai 4 ai 5 giorni circa. Le batterie al litio durano tra 1-2 settimane. Questa selezione utilizzerà diverse velocità di decadimento della tensione della batteria per ciascuno dei tipi di chimica della batteria e avviserà l'utente quando una batteria si trova a circa 8-10 ore dall'esaurimento."
+            "value" : "Le batterie alcaline e al litio decadono a velocità diverse. Le batterie alcaline tendono ad avere una caduta di tensione lineare nel tempo mentre le batterie al litio tendono a mantenere la tensione fino a metà della loro durata. In condizioni di utilizzo normali con in esecuzione Loop, in un microinfusore d'insulina non compatibile con MySentry (x22/x15), le batterie alcaline durano dai 4 ai 5 giorni circa. Le batterie al litio durano tra 1-2 settimane. Questa selezione utilizzerà diverse velocità di decadimento della tensione della batteria per ciascuno dei tipi di chimica della batteria e avviserà l'utente quando una batteria si trova a circa 8-10 ore dall'esaurimento."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アルカリ電池とリチウム電池では消耗速度が異なります。アルカリは徐々に電力が落ちるのに対し、リチウムは電池生命の前半は電圧を保持します。MySentryに互換性のないMinimed (x22/x15)でループを使用する場合は、アルカリ電池は4～5日、リチウム電池は1～2週間使用できることが多いです。それぞれの電池の種類の電圧消耗速度を設定して、電池生命が約8～10時間になるとユーザに知らせます。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alkaliske- og lithiumbatterier mister spenning med forskjellige kurver. Alkaliske har som regel en lineært minskende spenning, mens lithiumbatterier pleier å holde på spenningen gjennom omtrent halvparten av levetiden. Ved normalt bruk i en Non-MySentry kompatibel Minimed (x22/x15) insulinpumpe som kjører Loop, pleier alkaliske batterier å holde i 4 til 5 dager. Lithiumbatterier holder som regel 1-2 uker. Dette valget vil bruke forskjellige kurver for nedgang i batterispenning for hver av de forskjellige batteritypene, og varsle brukeren når batteriet er omtrent 8 til 10 timer fra å være tomt."
@@ -938,16 +1172,16 @@
             "value" : "Baterie alkaliczne i litowe różnią się szybkością rozładowywania. Baterie alkaliczne mają tendencję do liniowego spadku napięcia w czasie, natomiast baterie litowe mają tendencję do utrzymywania napięcia do momentu osiągnięcia połowy żywotności. W trakcie normalnego korzystania z Loop w niekompatybilnej z MySentry pompie (x22/x15), czas życia baterii alkalicznych wynosi ok. 4-5 dni. Żywotność baterii litowych wynosi ok. 1-2 tygodni. Wybór odpowiedniego typu baterii pozwoli na wybranie lepszego algorytmu zużycia baterii, dzięki czemu Loop będzie mógł wysłać ostrzeżenie, gdy zostanie ok. 8-10 godzin do całkowitego rozładowania."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Alkaline and Lithium batteries decay at differing rates. Alkaline tend to have a linear voltage drop over time whereas lithium cell batteries tend to maintain voltage until halfway through their lifespan. Under normal usage in a Non-MySentry compatible Minimed (x22/x15) insulin pump running Loop, Alkaline batteries last approximately 4 to 5 days. Lithium batteries last between 1-2 weeks. This selection will use different battery voltage decay rates for each of the battery chemistry types and alert the user when a battery is approximately 8 to 10 hours from failure."
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Baterias alcalinas e de lítio descarregam de formas diferentes. Baterias alcalinas tendem a perder voltagem linearmente, enquanto baterias de célula de lítio tendem a manter a voltagem até metade de sua vida útil. Em condições normais de uso do Loop em uma bomba Minimed que não utiliza o MySentry (x22/x15), baterias alcalinas devem durar entre 4 e 5 dias. Baterias de lítio duram entre 1 e 2 semanas. Essa seleção vai utilizar diferentes taxas de descarregamento para cada tipo de bateria e alertar o usuário quando a bateria estiver entre 8 e 10 horas de falhar."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baterii alcaline și cele cu litiu se descarcă diferit. La cele alcaline, tensiunea scade proporțional cu descărcare, pe când cele cu litiu mențin tensiunea normală pană aproape de descărcare completă. În condiții normale pe pompele Minimed care nu sunt compatibile cu MySentry (x22/x15), rulând Loop, bateriile alcaline durează 4-5 zile. Bateriile cu litiu durează aproximativ 1-2 săptămâni. Prin această opțiune se alege modul de calcul al descărcării bateriilor în funcție de tipul lor, astfel încât utilizatorul să fie anunțat cu 8-10 ore înainte de descărcare completă."
           }
         },
         "ru" : {
@@ -956,10 +1190,16 @@
             "value" : "Щелочные и литиевые батарейки садятся с различной скоростью. У щелочных падение линейное, в то время как литиевые сохраняют  напряжение в течение половины срока службы. При нормальном пользовании в помпе Minimed без Mysentry (x22/x15) с применением алгоритма ИПЖ щелочные батарейки служат примерно от 4 до 5 дней. Литиевые служат от 1 до 2 недель. Эта настройка будет использовать разную скорость падения напряжения батареек в зависимости от их химического типа и предупреждать пользователя за 8-10 часов до отказа "
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alkalické a lítiové batérie sa vybíjajú rozdielnou rýchlosťou. Alkalické majú tendenciu lineárne klesať v priebehu času, zatiaľ čo lítiové batérie majú tendenciu udržiavať napätie až do polovice svojej životnosti. Pri bežnom používaní v inzulínovej pumpe Minimed (x22/x15), ktorá nie je kompatibilná so systémom MySentry a beží v slučke, vydržia alkalické batérie približne 4 až 5 dní. Lítiové batérie vydržia 1 až 2 týždne. Pri tomto výbere sa pre každý typ chemického zloženia batérie použije iná rýchlosť úbytku napätia a používateľ bude upozornený, keď batériu delí približne 8 až 10 hodín od zlyhania."
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alkaline and Lithium batteries decay at differing rates. Alkaline tend to have a linear voltage drop over time whereas lithium cell batteries tend to maintain voltage until halfway through their lifespan. Under normal usage in a Non-MySentry compatible Minimed (x22/x15) insulin pump running Loop, Alkaline batteries last approximately 4 to 5 days. Lithium batteries last between 1-2 weeks. This selection will use different battery voltage decay rates for each of the battery chemistry types and alert the user when a battery is approximately 8 to 10 hours from failure."
+            "value" : "Alkaliska och litiumbatterier tappar spänning med olika hastighet. Alkaliska tenderar att ha ett linjärt spänningsfall över tiden, medan litiumcellsbatterier tenderar att behålla spänning fram till halva deras livslängd. Under normal användning, i en icke-MySentry-kompatibel Minimed (x22/x15) insulinpump som loopas, varar alkaliska batterier cirka 4 till 5 dagar. Litiumbatterier håller mellan 1–2 veckor. Detta val kommer att använda olika spänningsfall beroende på batterityp och varna användaren när ett batteri har cirka 8–10 timmar kvar av sin livslängd."
           }
         },
         "tr" : {
@@ -968,10 +1208,22 @@
             "value" : "Alkalin ve Lityum piller farklı oranlarda biterler. Alkali, zamanla doğrusal bir voltaj düşüşüne sahip olma eğilimindeyken, lityum hücreli piller, kullanım ömürlerinin yarısına kadar voltajı koruma eğilimindedir. MySentry uyumlu olmayan Minimed (x22/x15) insülin pompası ile çalışan Döngüde normal kullanım altında, Alkalin piller yaklaşık 4 ila 5 gün dayanırken, Lityum piller ise 1-2 hafta arasında dayanabilir. Bu seçim, pil kimyası türlerinin her biri için farklı pil voltajı oranlarını kullanır ve kullanıcıyı bir pilin bitmesine yaklaşık 8 ila 10 saat kaldığında uyarır."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Лужні та літієві батареї розкладаються з різною швидкістю. Лужні батареї, як правило, мають лінійне падіння напруги з часом, тоді як літієві батареї, як правило, зберігають напругу до середини свого терміну служби. За нормального використання інсулінової помпи Minimed (x22/x15), не сумісної з MySentry, працює Loop, лужних батарей вистачає приблизно на 4–5 днів. Літієві батареї працюють від 1 до 2 тижнів. Цей вибір використовуватиме різні швидкості спаду напруги батареї для кожного типу хімічного складу батареї та сповіщатиме користувача, коли до виходу з ладу батареї залишиться приблизно 8–10 годин."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pin kềm và pin lithium phân rã ở các mức độ khác nhau. Pin kềm có xu hướng giảm điện áp tuyến tính theo thời gian trong khi pin lithium có xu hướng duy trì điện áp cho đến khi hết nửa vòng đời. Trong điều kiện sử dụng bình thường trên bơm Minimed (loại X22 hay X15) khi chạy Loop, pin kiềm có thể dùng được trong khoảng 4 đến 5 ngày trong khi pin lithium dùng dc 2 tuần. Việc lựa chọn này được sử dụng theo các mức phân rã điện áp khác nhau cho mỗi loại pin hóa học và sẽ có cảnh báo đối với người dùng khi pin hỏng đạt khoảng từ 8-10 giờ."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Alkaline and Lithium batteries decay at differing rates. Alkaline tend to have a linear voltage drop over time whereas lithium cell batteries tend to maintain voltage until halfway through their lifespan. Under normal usage in a Non-MySentry compatible Minimed (x22/x15) insulin pump running Loop, Alkaline batteries last approximately 4 to 5 days. Lithium batteries last between 1-2 weeks. This selection will use different battery voltage decay rates for each of the battery chemistry types and alert the user when a battery is approximately 8 to 10 hours from failure."
           }
         },
         "zh-Hans" : {
@@ -985,22 +1237,34 @@
     "Are you sure you want to delete this Pump?" : {
       "comment" : "Text to confirm delete this pump",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "هل أنت متأكد أنك تريد حذف هذه المضخة؟"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Er du sikker på, at du vil fjerne denne pumpe?"
+            "value" : "Sikker på, at denne pumpe skal fjernes?"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bist Du sicher, dass Du diese Pumpe löschen möchtest?"
+            "value" : "Sind Sie sicher, dass Sie diese Pumpe löschen wollen?"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "¿Está seguro de que desea eliminar esta bomba?"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this Pump?"
           }
         },
         "fr" : {
@@ -1011,17 +1275,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "בטוח שברצונך למחוק את משאבה זו?"
+            "state" : "new",
+            "value" : "Are you sure you want to delete this Pump?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this Pump?"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sei sicuro di voler eliminare questa pompa?"
+            "value" : "Sei sicuro di voler eliminare questo microinfusore?"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Er du sikker på at du vil slette denne pumpen?"
@@ -1039,10 +1309,16 @@
             "value" : "Czy na pewno chcesz usunąć tę pompę?"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sunteți sigur că doriți să ștergeți această pompă?"
+            "state" : "new",
+            "value" : "Are you sure you want to delete this Pump?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this Pump?"
           }
         },
         "ru" : {
@@ -1051,22 +1327,58 @@
             "value" : "Вы уверены, что хотите удалить эту помпу?"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ste si istí, že chcete túto pumpu odstrániť?"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Är du säker på att du vill radera denna pump?"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bu Pompayı silmek istediğinizden emin misiniz?"
           }
         },
-        "zh-Hans" : {
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您确定要删除此泵吗？"
+            "value" : "Ви впевнені, що хочете видалити цю помпу?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bạn có chắc muốn xóa bơm này không?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this Pump?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this Pump?"
           }
         }
       }
     },
     "Battery Chemistry" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1079,10 +1391,34 @@
             "value" : "Batteriechemie"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
+          }
+        },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "כימיית סוללה"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
           }
         },
         "it" : {
@@ -1091,7 +1427,7 @@
             "value" : "Chimica della batteria"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Batterikjemi"
@@ -1109,10 +1445,16 @@
             "value" : "Rodzaj baterii"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chimia bateriei"
+            "state" : "new",
+            "value" : "Battery Chemistry"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
           }
         },
         "ru" : {
@@ -1121,10 +1463,46 @@
             "value" : "Тип батарейки"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batterikemi"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pil Kimyası"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
           }
         }
       }
@@ -1132,6 +1510,12 @@
     "Battery: %1$@ volts\n" : {
       "comment" : "The format string describing pump battery voltage: (1: battery voltage)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery: %1$@ volts\n"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1168,19 +1552,19 @@
             "value" : "סוללה: %1$@ וולט\n"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery: %1$@ volts\n"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Batteria: %1$@ volts\n"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "電池: %1$@ ボルト\n\n"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Batteri: %1$@ volt"
@@ -1198,22 +1582,28 @@
             "value" : "Bateria: %1$@ V\n"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery: %1$@ volts\n"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bateria: %1$@ volts\n"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baterie: %1$@ volți\n"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Батарея: %1$@ вольт\n"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery: %1$@ volts\n"
           }
         },
         "sv" : {
@@ -1228,10 +1618,22 @@
             "value" : "Pil: %1$@ volt\n"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery: %1$@ volts\n"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pin: %1$@ volts\n"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery: %1$@ volts\n"
           }
         },
         "zh-Hans" : {
@@ -1245,6 +1647,12 @@
     "Best Frequency" : {
       "comment" : "The label indicating the best radio frequency",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أفضل تردد"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1277,23 +1685,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "התדר הטוב ביותר"
+            "state" : "new",
+            "value" : "Best Frequency"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Best Frequency"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Frequenza migliore"
+            "value" : "La migliore Frequenza"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "最良周波数"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Beste frekvens"
@@ -1302,7 +1710,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Beste Frequentie"
+            "value" : "Beste frequentie"
           }
         },
         "pl" : {
@@ -1311,16 +1719,16 @@
             "value" : "Najlepsza częstotliwość"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Best Frequency"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Melhor Frequência"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frecvența optimă"
           }
         },
         "ru" : {
@@ -1329,10 +1737,16 @@
             "value" : "Лучшая частота"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Najlepšia Frekvencia"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Besta frekvensen"
+            "value" : "Bästa frekvensen"
           }
         },
         "tr" : {
@@ -1341,10 +1755,22 @@
             "value" : "En İyi Frekans"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Найкраща частота"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tần số tối ưu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Best Frequency"
           }
         },
         "zh-Hans" : {
@@ -1358,6 +1784,12 @@
     "Bolusing: %1$@\n" : {
       "comment" : "The format string describing pump bolusing state: (1: bolusing)",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolusing: %1$@\n"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1394,19 +1826,19 @@
             "value" : "מזריק בולוס: %1$@\n"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolusing: %1$@\n"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolo in corso: %1$@\n"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラス注入中: %1$@\n\n"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gir bolus: %1$@"
@@ -1424,22 +1856,28 @@
             "value" : "Podawanie bolusa: %1$@\n"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolusing: %1$@\n"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Injetando Bolus: %1$@\n"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se livrează: %1$@\n"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Болюс: %1$@\n"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolusing: %1$@\n"
           }
         },
         "sv" : {
@@ -1454,10 +1892,22 @@
             "value" : "Bolus: %1$@\n"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolusing: %1$@\n"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang tiêm liều bolus: %1$@\n"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolusing: %1$@\n"
           }
         },
         "zh-Hans" : {
@@ -1475,12 +1925,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إلغاء"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zrušit"
           }
         },
         "da" : {
@@ -1504,7 +1948,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kumoa"
+            "value" : "Peru"
           }
         },
         "fr" : {
@@ -1515,29 +1959,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ביטול"
+            "state" : "new",
+            "value" : "Cancel"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "निरस्त"
+            "value" : "Mégse"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annulla"
+            "value" : "Cancella"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avbryt"
@@ -1555,16 +1993,16 @@
             "value" : "Anuluj"
           }
         },
-        "pt-BR" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancelar"
           }
         },
-        "ro" : {
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Renunță"
+            "value" : "Cancelar"
           }
         },
         "ru" : {
@@ -1588,13 +2026,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İptal"
+            "value" : "Vazgeç"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відмінити"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hủy bỏ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
           }
         },
         "zh-Hans" : {
@@ -1608,10 +2058,16 @@
     "Canceling Temp Basal" : {
       "comment" : "Title text for suspend resume button when temp basal canceling",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إلغاء الجرعة الأساسية المؤقتة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annuller midlertidig basal"
+            "value" : "Afbryder midlertidig basal"
           }
         },
         "de" : {
@@ -1640,23 +2096,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מבטל בזאלי זמני"
+            "state" : "new",
+            "value" : "Canceling Temp Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canceling Temp Basal"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annullamento basale temporanea in corso"
+            "value" : "Annullamento Basale Temp"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時基礎レートをキャンセルします"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avbryter midlertidig basal"
@@ -1665,7 +2121,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tijdelijk Basaal Annuleren"
+            "value" : "Tijdelijk basaal annuleren"
           }
         },
         "pl" : {
@@ -1674,22 +2130,28 @@
             "value" : "Anulowanie tymczasowej dawki podstawowej"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canceling Temp Basal"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancelar Basal Temporária"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oprește bazala temporară"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отмена врем базала"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruší sa dočasný bazál"
           }
         },
         "sv" : {
@@ -1704,16 +2166,28 @@
             "value" : "Geçici Bazalı İptal Et"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скасування тимчасового базалу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang hủy liều Basal tạm thời"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canceling Temp Basal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消临时基础率"
+            "state" : "new",
+            "value" : "Canceling Temp Basal"
           }
         }
       }
@@ -1721,10 +2195,16 @@
     "Changing" : {
       "comment" : "Text shown in basal rate space when basal is changing",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تغيير"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ændrer"
+            "value" : "Skifter"
           }
         },
         "de" : {
@@ -1739,6 +2219,12 @@
             "value" : "Cambiando"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changing"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1747,17 +2233,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "משנה"
+            "state" : "new",
+            "value" : "Changing"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changing"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Modifica in corso"
+            "value" : "Modifica"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Endrer"
@@ -1775,10 +2267,16 @@
             "value" : "Zmiana"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se modifică"
+            "state" : "new",
+            "value" : "Changing"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changing"
           }
         },
         "ru" : {
@@ -1787,10 +2285,46 @@
             "value" : "Изменение"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zmena"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Byter"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Değiştirme"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зміна"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đang thay đổi"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changing"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changing"
           }
         }
       }
@@ -1798,10 +2332,10 @@
     "Changing time…" : {
       "comment" : "Progress message for changing pump time.",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Měním čas…"
+            "value" : "تغيير الوقت…"
           }
         },
         "da" : {
@@ -1836,23 +2370,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "משנה זמן…"
+            "state" : "new",
+            "value" : "Changing time…"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changing time…"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Modifica orario in corso..."
+            "value" : "Modifica ora in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "時間を変えています"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Endrer tid..."
@@ -1861,7 +2395,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tijd Aanpassen..."
+            "value" : "Tijd aanpassen..."
           }
         },
         "pl" : {
@@ -1870,16 +2404,16 @@
             "value" : "Zmiana czasu…"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changing time…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Alterando a hora..."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se modifică ora…"
           }
         },
         "ru" : {
@@ -1906,16 +2440,28 @@
             "value" : "Saat değiştiriliyor…"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зміна часу…"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang thay đổi giờ…"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changing time…"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在修改时间…"
+            "value" : "更改时间"
           }
         }
       }
@@ -1923,22 +2469,34 @@
     "Choose the type of battery you are using in your pump for better alerting about low battery conditions." : {
       "comment" : "Instructions on selecting battery chemistry type",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "اختر نوع البطارية التي تستخدمها في مضختك لتحسين التنبيهات حول حالات انخفاض البطارية."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vælg den batteritype, du bruger i din pumpe, for at få bedre advarsler om lavt batteri."
+            "value" : "Vælg den batteritype, der bruges i pumpen, for at få bedre advarsler om lavt batteri."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wähle den Batterietyp, den Du in Deiner Pumpe verwendest, um besser über einen niedrigen Batteriestand informiert zu werden."
+            "value" : "Wählen Sie den Batterietyp, den Sie in Ihrer Pumpe verwenden, um besser über einen niedrigen Batteriestand informiert zu werden."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Elija el tipo de batería que está utilizando en su bomba para una mejor alerta sobre las condiciones de batería baja."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose the type of battery you are using in your pump for better alerting about low battery conditions."
           }
         },
         "fr" : {
@@ -1949,17 +2507,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "בחר את סוג הסוללה של המשאבה שלך כדי לקבל התראות טובות יותר כשזמן הסוללה נמוך."
+            "state" : "new",
+            "value" : "Choose the type of battery you are using in your pump for better alerting about low battery conditions."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose the type of battery you are using in your pump for better alerting about low battery conditions."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Seleziona il tipo di batteria che stai utilizzando nella pompa per ricevere più facilmente informazioni sulle condizioni della batteria."
+            "value" : "Seleziona il tipo di batteria che stai utilizzando nel microinfusore per ricevere più facilmente informazioni sulle condizioni della batteria."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velg typen batteri du bruker i pumpen for bedre å varsle om lavt batteri."
@@ -1968,19 +2532,25 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kies het type batterij dat in de pomp wordt gebruikt, voor optimalisering van waarschuwing voor laag batterij niveau."
+            "value" : "Kies het type batterij dat je gebruikt in je pomp om beter te kunnen waarschuwen voor een te laag batterij niveau."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wybierz rodzaj baterii używanej w pompie, aby lepiej ostrzegać o niskim stanie baterii."
+            "value" : "Wybierz typ baterii używanej w pompie, aby lepiej ostrzegać o niskim stanie baterii."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alegeți tipul de baterie pe care îl utilizați în pompă pentru o mai bună avertizare cu privire la condițiile scăzute ale bateriei."
+            "state" : "new",
+            "value" : "Choose the type of battery you are using in your pump for better alerting about low battery conditions."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose the type of battery you are using in your pump for better alerting about low battery conditions."
           }
         },
         "ru" : {
@@ -1995,16 +2565,40 @@
             "value" : "Vyberte typ batérie, ktorú používate v pumpe, aby ste mohli byť lepšie upozornení na stav vybitia batérie."
           }
         },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välj vilken typ av batteri du använder i din pump."
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Düşük pil koşulları hakkında daha iyi uyarı almak için pompanızda kullandığınız pil türünü seçin."
           }
         },
-        "zh-Hans" : {
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "选择您在泵中使用的电池类型，以便更好地提醒电池电量不足的情况。"
+            "value" : "Виберіть тип акумулятора, який ви використовуєте у своїй помпі, щоб краще сповіщати про розряд акумулятора."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn loại pin bạn đang sử dụng trong máy bơm để cảnh báo tốt hơn về tình trạng pin yếu."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose the type of battery you are using in your pump for better alerting about low battery conditions."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose the type of battery you are using in your pump for better alerting about low battery conditions."
           }
         }
       }
@@ -2015,13 +2609,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "المعطيات"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurace"
+            "value" : "ضبط"
           }
         },
         "da" : {
@@ -2039,13 +2627,13 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Configuración"
+            "value" : "Configuracion"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Määritykset"
+            "state" : "new",
+            "value" : "Configuration"
           }
         },
         "fr" : {
@@ -2056,50 +2644,50 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Configuration"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "הגדרות"
+            "value" : "Beállítások"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Configurazione"
+            "value" : "Impostazioni"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "コンフィグレーション"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurasjon"
+            "value" : "Oppsett"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Configuratie"
+            "value" : "Instellingen"
           }
         },
         "pl" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Configuration"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Konfiguracja"
+            "value" : "Ajustes"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Configuração"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurare"
+            "value" : "Ajustes"
           }
         },
         "ru" : {
@@ -2111,7 +2699,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Konfigurácia"
+            "value" : "Nastavenie"
           }
         },
         "sv" : {
@@ -2123,13 +2711,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Konfigürasyon"
+            "value" : "Yapılandırma"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cấu hình"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Configuration"
           }
         },
         "zh-Hans" : {
@@ -2143,6 +2743,12 @@
     "Connect" : {
       "comment" : "Button title to connect to pump during setup",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "توصيل"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2170,13 +2776,19 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Relier"
+            "value" : "Se connecter"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Connect"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Csatlakozás"
           }
         },
         "it" : {
@@ -2185,13 +2797,7 @@
             "value" : "Connetti"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "接続"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Koble til"
@@ -2209,22 +2815,28 @@
             "value" : "Połącz"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conectar"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectare"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Соединение с помпой"
+            "value" : "Подключить"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pripojiť"
           }
         },
         "sv" : {
@@ -2236,13 +2848,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bağla"
+            "value" : "Bağlan"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підключити"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connect"
           }
         },
         "zh-Hans" : {
@@ -2256,10 +2880,10 @@
     "Continue" : {
       "comment" : "Text for continue button",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pokračovat"
+            "value" : "تابع"
           }
         },
         "da" : {
@@ -2271,7 +2895,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Weiter"
+            "value" : "Fortsetzen"
           }
         },
         "es" : {
@@ -2294,14 +2918,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "המשך"
+            "state" : "new",
+            "value" : "Continue"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "जारी"
+            "state" : "new",
+            "value" : "Continue"
           }
         },
         "it" : {
@@ -2310,13 +2934,7 @@
             "value" : "Continua"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "次へ"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fortsett"
@@ -2325,7 +2943,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ga Verder"
+            "value" : "Vervolg"
           }
         },
         "pl" : {
@@ -2334,16 +2952,16 @@
             "value" : "Kontynuuj"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Continue"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continuar"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuă"
           }
         },
         "ru" : {
@@ -2370,10 +2988,28 @@
             "value" : "Devam et"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продовжити"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tiếp tục"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Continue"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "继续"
           }
         }
       }
@@ -2381,10 +3017,16 @@
     "Delete Pump" : {
       "comment" : "Button label for removing Pump\nText to delete pump",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حذف المضخة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fjern pumpe"
+            "value" : "Slet pumpe"
           }
         },
         "de" : {
@@ -2413,23 +3055,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מחק משאבה"
+            "state" : "new",
+            "value" : "Delete Pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Pump"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Elimina pompa"
+            "value" : "Cancella Microinfusore"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプを削除"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Slette pumpe"
@@ -2447,22 +3089,28 @@
             "value" : "Usuń pompę"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Pump"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Deletar Bomba"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elimină pompa"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Удалить помпу"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odstrániť pumpu"
           }
         },
         "sv" : {
@@ -2477,10 +3125,22 @@
             "value" : "Pompayı Sil"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалити помпу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xóa bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Pump"
           }
         },
         "zh-Hans" : {
@@ -2494,6 +3154,12 @@
     "Devices" : {
       "comment" : "Header for devices section of RileyLinkSetupView",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الأجهزة"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2514,20 +3180,26 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laitteet"
+            "state" : "new",
+            "value" : "Devices"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dispositifs"
+            "value" : "Appareils"
           }
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Devices"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "מכשירים"
+            "value" : "Eszközök"
           }
         },
         "it" : {
@@ -2536,13 +3208,7 @@
             "value" : "Dispositivi"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "デバイス"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enheter"
@@ -2556,20 +3222,20 @@
         },
         "pl" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Devices"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Urządzenia"
+            "value" : "Dispositivos"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dispositivos"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dispozitive"
           }
         },
         "ru" : {
@@ -2593,13 +3259,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cihazlar"
+            "value" : "Aygıtlar"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пристрої"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thiết bị"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Devices"
           }
         },
         "zh-Hans" : {
@@ -2613,6 +3291,12 @@
     "Do not use MySentry" : {
       "comment" : "Description for option to not use MySentry",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا تستخدم MySentry"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2631,6 +3315,12 @@
             "value" : "No utilice MySentry"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do not use MySentry"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2639,8 +3329,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "אל תשתמש ב-MySentry"
+            "state" : "new",
+            "value" : "Do not use MySentry"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do not use MySentry"
           }
         },
         "it" : {
@@ -2649,7 +3345,7 @@
             "value" : "Non utilizzare MySentry"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ikke bruk MySentry"
@@ -2667,10 +3363,16 @@
             "value" : "Nie używaj MySentry"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu utilizați MySentry"
+            "state" : "new",
+            "value" : "Do not use MySentry"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do not use MySentry"
           }
         },
         "ru" : {
@@ -2679,32 +3381,80 @@
             "value" : "Не использовать MySentry"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nepoužívať službu MySentry"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Använd inte MySentry"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "MySentry'i kullanmayın"
           }
         },
-        "zh-Hans" : {
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不使用 MySentry"
+            "value" : "Не використовувати MySentry"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không sử dụng MySentry"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do not use MySentry"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do not use MySentry"
           }
         }
       }
     },
     "Done" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تمّ"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Udført"
+            "value" : "OK"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fertig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hecho"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valmis"
           }
         },
         "fr" : {
@@ -2715,8 +3465,14 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Done"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "בוצע"
+            "value" : "Kész"
           }
         },
         "it" : {
@@ -2725,7 +3481,7 @@
             "value" : "Fine"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ferdig"
@@ -2734,19 +3490,25 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gereed"
+            "value" : "OK"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gotowe"
+            "state" : "new",
+            "value" : "Done"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Realizat"
+            "value" : "OK"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
         "ru" : {
@@ -2755,10 +3517,46 @@
             "value" : "Готово"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hotovo"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klar"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tamamlandı"
+            "value" : "Tamam"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xong"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Done"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "完成"
           }
         }
       }
@@ -2804,23 +3602,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "שגיאה בביצוע חידוש"
+            "state" : "new",
+            "value" : "Error Resuming"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Resuming"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Errore durante la ripresa"
+            "value" : "Errore durante la Ripresa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再開エラー"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Feil ved gjenopptagelse"
@@ -2829,7 +3627,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fout Bij Hervatten"
+            "value" : "Fout bij hervatten"
           }
         },
         "pl" : {
@@ -2838,16 +3636,16 @@
             "value" : "Błąd wznawiania"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Resuming"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erro ao Retomar"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare în timpul reluării"
           }
         },
         "ru" : {
@@ -2874,16 +3672,28 @@
             "value" : "Sürdürme Hatası"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помилка відновлення"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lỗi khi đang tái thực hiện"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Resuming"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "无法恢复"
+            "value" : "恢复输注错误"
           }
         }
       }
@@ -2891,10 +3701,10 @@
     "Error Suspending" : {
       "comment" : "The alert title for a suspend error",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chyba při pozastavení"
+            "state" : "new",
+            "value" : "Error Suspending"
           }
         },
         "da" : {
@@ -2929,8 +3739,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "שגיאה בביצוע השהייה"
+            "state" : "new",
+            "value" : "Error Suspending"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Suspending"
           }
         },
         "it" : {
@@ -2939,13 +3755,7 @@
             "value" : "Errore durante l’interruzione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時中止エラー"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kunne ikke stoppe"
@@ -2954,7 +3764,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fout Bij Onderbreken"
+            "value" : "Fout bij onderbreken"
           }
         },
         "pl" : {
@@ -2963,16 +3773,16 @@
             "value" : "Błąd wstrzymywania"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Suspending"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Erro ao Suspender"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare în timpul suspendării"
           }
         },
         "ru" : {
@@ -2999,10 +3809,22 @@
             "value" : "Askıya Alma Hatası"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помилка призупинення"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lỗi khi đang tạm ngưng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Suspending"
           }
         },
         "zh-Hans" : {
@@ -3016,16 +3838,16 @@
     "Error Syncing Time" : {
       "comment" : "The alert title for an error while synching time",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chyba při synchronizaci času"
+            "value" : "خطأ في مزامنة الوقت"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fejl ved synkronisering af tid"
+            "value" : "Fejl under tidssynk"
           }
         },
         "de" : {
@@ -3040,6 +3862,12 @@
             "value" : "Error de sincronización de tiempo"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Syncing Time"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3048,17 +3876,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "שגיאה בסנכרון זמן"
+            "state" : "new",
+            "value" : "Error Syncing Time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Syncing Time"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Errore durante la sincronizzazione dell'orario"
+            "value" : "Errore durante la sincronizzazione"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Feil ved synkroniseringstid"
@@ -3067,7 +3901,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fout Synchroniseren Tijd"
+            "value" : "Fout bij synchroniseren tijd"
           }
         },
         "pl" : {
@@ -3076,10 +3910,16 @@
             "value" : "Błąd synchronizacji czasu"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare la sincronizarea timpului"
+            "state" : "new",
+            "value" : "Error Syncing Time"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Syncing Time"
           }
         },
         "ru" : {
@@ -3088,16 +3928,46 @@
             "value" : "Ошибка синхронизации времени"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chyba synchronizácie času"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fel vid synkronisering av tid"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Zaman Senkronizasyon Hatası"
           }
         },
-        "zh-Hans" : {
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "同步时间错误"
+            "value" : "Помилка при синхронізації часу"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lỗi đồng bộ thời gian"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Syncing Time"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Syncing Time"
           }
         }
       }
@@ -3105,10 +3975,10 @@
     "Fetching glucose…" : {
       "comment" : "Progress message for fetching pump glucose.",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Načítání glukózy…"
+            "value" : "جارٍ جلب الجلوكوز…"
           }
         },
         "da" : {
@@ -3143,23 +4013,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מושך רמת סוכר…"
+            "state" : "new",
+            "value" : "Fetching glucose…"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching glucose…"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recupero glicemie in corso…"
+            "value" : "Sincronizza glicemie…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "グルコースを取得しています..."
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Henter blodsukkerverdi…"
@@ -3177,22 +4047,28 @@
             "value" : "Pobieranie glukozy…"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching glucose…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Buscando glicose…"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obținerea glicemiei…"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Получаю гликемию…"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Získavanie glykémie…"
           }
         },
         "sv" : {
@@ -3207,10 +4083,22 @@
             "value" : "Glikoz alınıyor…"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отримую глікемію."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang lấy dữ liệu đường huyết…"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching glucose…"
           }
         },
         "zh-Hans" : {
@@ -3224,10 +4112,10 @@
     "Fetching history…" : {
       "comment" : "Progress message for fetching pump history.",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Načítání historie…"
+            "value" : "جارٍ جلب التاريخ…"
           }
         },
         "da" : {
@@ -3262,23 +4150,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מושך היסטוריה…"
+            "state" : "new",
+            "value" : "Fetching history…"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching history…"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recupero cronologia in corso…"
+            "value" : "Sincronizza storia…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "履歴を取得しています..."
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Henter historikk…"
@@ -3296,22 +4184,28 @@
             "value" : "Pobieranie historii…"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching history…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "`Buscando histórico…"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obținerea istoricului…"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Получаю логи…"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Získavanie histórie…"
           }
         },
         "sv" : {
@@ -3326,10 +4220,22 @@
             "value" : "Geçmiş Alınıyor…"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отримую логи..."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang lấy thông tin…"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching history…"
           }
         },
         "zh-Hans" : {
@@ -3343,10 +4249,10 @@
     "Fetching pump model…" : {
       "comment" : "Progress message for fetching pump model.",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Načítání modelu pumpy…"
+            "value" : "جاري جلب نموذج المضخة…"
           }
         },
         "da" : {
@@ -3381,23 +4287,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מושך דגם משאבה…"
+            "state" : "new",
+            "value" : "Fetching pump model…"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching pump model…"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Recupero del modello della pompa in corso…"
+            "value" : "Sincronizza modello micro…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプモデルを取得しています ..."
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Henter pumpemodell…"
@@ -3415,22 +4321,28 @@
             "value" : "Pobieranie modelu pompy…"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching pump model…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Buscando modelo da bomba..."
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obținerea modelului pompei…"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Получаю модель помпы…"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Získavanie modelu pumpy…"
           }
         },
         "sv" : {
@@ -3445,10 +4357,22 @@
             "value" : "Pompa Modeli Alınıyor…"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отримую модель помпи…"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang lấy model bơm…"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching pump model…"
           }
         },
         "zh-Hans" : {
@@ -3462,10 +4386,10 @@
     "Firmware Version" : {
       "comment" : "The title of the cell showing the pump firmware version",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verze firmwaru"
+            "value" : "إصدار البرنامج الثابت"
           }
         },
         "da" : {
@@ -3477,31 +4401,37 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Firmware Version"
+            "value" : "Firmware-Version"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Versión del programa"
+            "value" : "Versión del firmware"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laiteohjelmiston versio"
+            "state" : "new",
+            "value" : "Firmware Version"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Version du micrologiciel"
+            "value" : "Version du firmware"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "גרסת קושחה"
+            "state" : "new",
+            "value" : "Firmware Version"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Firmware Version"
           }
         },
         "it" : {
@@ -3510,16 +4440,10 @@
             "value" : "Versione firmware"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ファームウェアバージョン"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Firmware versjon"
+            "value" : "Fastvareversjon"
           }
         },
         "nl" : {
@@ -3530,49 +4454,67 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wersja oprogramowania"
+            "state" : "new",
+            "value" : "Firmware Version"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Firmware Version"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão do Firmware"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versiunea Firmware"
+            "state" : "new",
+            "value" : "Firmware Version"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Firmware Version"
+            "value" : "Версия прошивки"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verzia firmvéru"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Firmware"
+            "value" : "Firmware-version"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Donanım yazılımı sürümü"
+            "value" : "Aygıt Yazılımı Sürümü"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версія прошивки"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Chương trình cơ sở"
+            "value" : "Phiên bản phần mềm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Firmware Version"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Firmware Version"
           }
         }
@@ -3581,40 +4523,52 @@
     "Insulin\nSuspended" : {
       "comment" : "Text shown in insulin delivery space when insulin suspended",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inzulín pozastaven"
+            "value" : "الأنسولين\nمعلق"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin \nsuspenderet"
+            "value" : "Insulin\nsuspenderet"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinabgabe\nunterbrochen"
+            "value" : "Insulin\nAusgesetzt"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina Suspendida"
+            "value" : "Insulina\nSuspendida"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insuliini\nKeskeytetään"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insuline\nSuspendue"
+            "value" : "Suspension de l'insuline\n"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "אינסולין\nמושהה"
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
           }
         },
         "it" : {
@@ -3623,16 +4577,16 @@
             "value" : "Insulina \nSospesa"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulintilførsel utsatt"
+            "value" : "Insulin\n Suspendert"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insuline\nOnderbroken"
+            "value" : "Insuline\nopgeschort"
           }
         },
         "pl" : {
@@ -3641,22 +4595,64 @@
             "value" : "Podawanie\nzawieszone"
           }
         },
-        "ro" : {
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
+          }
+        },
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Administrarea insulinei suspendată"
+            "value" : "Insulina\nSuspenso"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Подача инсулина остановлена"
+            "value" : "Подача инсулина приостановлена"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inzulín\nPozastavený"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insulin\nAvstängd"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İnsülin\nAskıya alındı"
+            "value" : "İnsülin\nAskıya Alındı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "胰岛素\n暂停使用"
           }
         }
       }
@@ -3668,12 +4664,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "توصيل الأنسولين"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podávání inzulínu"
           }
         },
         "da" : {
@@ -3691,12 +4681,12 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin Delivery"
+            "value" : "Administración de insulina"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Insulin Delivery"
           }
         },
@@ -3708,26 +4698,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "אינסולין שהוזלף"
+            "state" : "new",
+            "value" : "Insulin Delivery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Delivery"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erogazione insulina"
+            "value" : "Insulina Somministrata"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin Delivery"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gitt insulin"
+            "value" : "Insulintilførsel"
           }
         },
         "nl" : {
@@ -3738,26 +4728,26 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podaż insuliny"
+            "state" : "new",
+            "value" : "Insulin Delivery"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Delivery"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulin Delivery"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Insulin Delivery"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin Delivery"
+            "value" : "Подача инсулина"
           }
         },
         "sk" : {
@@ -3769,19 +4759,37 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin Delivery"
+            "value" : "Insulintillförsel"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İnsulin İletimi"
+            "value" : "İnsülin İletimi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подання Інсуліну"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Khối lượng tiêm insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Delivery"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "胰岛素输注"
           }
         }
       }
@@ -3789,16 +4797,16 @@
     "Insulin delivery can be determined from the pump by either interpreting the event history or comparing the reservoir volume over time. Reading event history allows for a more accurate status graph and uploading up-to-date treatment data to Nightscout, at the cost of faster pump battery drain and the possibility of a higher radio error rate compared to reading only reservoir volume. If the selected source cannot be used for any reason, the system will attempt to fall back to the other option." : {
       "comment" : "Instructions on selecting an insulin data source",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Podaný inzulín může být zjištěn z pumpy buď interpretací historie událostí nebo porovnáváním objemu zásobníku v čase. Čtení historie umožňuje zobrazení přesnějšího stavového grafu a upload aktualních dat do Nightscoutu za cenu rychlejšího vyčerpání baterie pumpy and případné vyšší chybovosti přenosu v porovnání s použitím metody porovnávání zásobníku. Pokud vybraná metoda selže z jakéhokoli důvodu, systém se pokusí vrátit k použití druhé metody."
+            "value" : "يمكن تحديد تسليم الأنسولين من المضخة إما عن طريق تفسير تاريخ الأحداث أو مقارنة حجم الخزان مع مرور الوقت. قراءة تاريخ الأحداث توفر رسمًا بيانيًا أكثر دقة للحالة وتحديث بيانات العلاج إلى Nightscout، ولكنها تؤدي إلى استنزاف أسرع لبطارية المضخة وإمكانية حدوث معدل أخطاء راديو أعلى مقارنةً بقراءة حجم الخزان فقط. إذا لم يكن بالإمكان استخدام المصدر المحدد لأي سبب كان، سيحاول النظام العودة إلى الخيار الآخر."
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Levering af insulin kan blive bestemt fra pumpen ved enten at tolke på begivenhedshistorikken eller ved at sammenligne volumen af reservoiret over tid. Aflæsning af begivenhedshistorik kan give mere præcise statusgrafer og uploading af up-to-date behandlings data til Nightscout, men betyder hurtigere dræning af pumpebatteriet, risiko for højere fejlrate i radiokommunikation i forhold til aflæsning af volumen af reservoiret. Hvis den valgte kilde ikke kan anvendes,så vil systemet falde tilbage på den anden mulighed."
+            "value" : "Insulinlevering fra pumpen kan afgøres ved enten fortolkning af begivenhedshistorikken eller ved sammenligning af reservoirvolumen over tid. Aflæsning af begivenhedshistorik muliggør en mere præcise statusgraf og upload af af ajourførte behandlingsdata til Nightscout, hvilket betyder hurtigere dræning af pumpebatteriet, risiko for højere fejlrate i radiokommunikation ift. aflæsning af reservoirvolumen. Kan den valgte kilde ikke anvendes, forsøger systemet at falde tilbage på den anden mulighed."
           }
         },
         "de" : {
@@ -3827,23 +4835,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "נתוני הזלפת האינסולין יכולים להיקרא מיומן האירועים, או באמצעות השוואה של מאגר האינסולין לאורך זמן. קריאה מיומן האירועים תאפשר גרף מצב מדוייק ועדכני יותר ל-Nightscout, אך זמן סוללת המשאבה יכול להתקצר, עם סיכוי גבוה יותר לתקלות שידור. אם מקור המידע שבחרת לא זמין מכל סיבה, Loop ינסה אוטומטית לקרוא ממקור המידע האחר."
+            "state" : "new",
+            "value" : "Insulin delivery can be determined from the pump by either interpreting the event history or comparing the reservoir volume over time. Reading event history allows for a more accurate status graph and uploading up-to-date treatment data to Nightscout, at the cost of faster pump battery drain and the possibility of a higher radio error rate compared to reading only reservoir volume. If the selected source cannot be used for any reason, the system will attempt to fall back to the other option."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin delivery can be determined from the pump by either interpreting the event history or comparing the reservoir volume over time. Reading event history allows for a more accurate status graph and uploading up-to-date treatment data to Nightscout, at the cost of faster pump battery drain and the possibility of a higher radio error rate compared to reading only reservoir volume. If the selected source cannot be used for any reason, the system will attempt to fall back to the other option."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'insulina erogata può essere determinata dalla pompa sia interpretando la cronologia eventi o confrontando il volume del serbatoio nel tempo. La lettura della cronologia degli eventi consente una statistica più accurata e trasmette dati sempre aggiornati a Nightscout, a discapito di un maggiore consumo di batteria e con la possibilità di incorrere in un maggior tasso di errore di comunicazione rispetto alla sola lettura del volume del serbatoio. Se la sorgente selezionata non può essere utilizzata per qualsiasi ragione, il sistema tenterà di ripiegare sull'altra opzione."
+            "value" : "L'insulina somministrata può essere determinata dalla pompa sia interpretando la cronologia eventi o confrontando il volume del serbatoio nel tempo. La lettura della cronologia degli eventi consente una statistica più accurata e trasmette dati sempre aggiornati a Nightscout, a discapito di un maggiore consumo di batteria e con la possibilità di incorrere in un maggior tasso di errore di comunicazione rispetto alla sola lettura del volume del serbatoio. Se la sorgente selezionata non può essere utilizzata per qualsiasi ragione, il sistema tenterà di ripiegare sull'altra opzione."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリン注入は、イベント履歴を解釈する、またはリザーバの残量を計ることにより決定されます。イベント履歴を読み取ることにより、ステータスグラフがより正確になり、Nightscoutに最新のトリートメントデータをアップロードできます。リザーバの残量のみを計るよりも、ポンプの電池寿命が短くなり、無線周波数のエラーが増える可能性があります。選択されているデータソースが何らかの事情により使えない場合は、システムはもう片方のソースを使用します。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulintilførsel kan hentes fra pumpa, enten ved å tolke hendelsehistorikken, eller ved å sammenligne reservoarvolumet over tid. Ved å lese hendelsehistorikken får man mer nøyaktig statuskurve og kan laste opp oppdaterte hendelser til Nightscout. Ulempen er høyere batteriforbruk i pumpa, og muligheten for større antall feil ved radiokommunikasjon - sammenlignet med å bare lese reservoarvolumet. Hvis den valgte kilden av noen grunn ikke kan brukes, vill systemet prøve den andre måten."
@@ -3858,19 +4866,19 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Podaż insuliny jest ustalana dzięki pobieraniu danych z pompy. Może się to odbywać na dwa sposoby: poprzez interpretację historii zdarzeń lub poprzez porównywanie objętości zbiornika na insulinę w czasie. Interpretacja historii zdarzeń pozwala na dokładniejsze odwzorowanie wykresu statusu i wysyłanie aktualnych danych dotyczących leczenia do Nightscout'a. Odbywa się to kosztem szybszego zużycia baterii i większym ryzykiem błędu transmisji radiowej względem drugiego sposobu, czyli porównywania objętości zbiornika na insulinę w czasie. Jeśli wybrany sposób z jakiegoś powodu nie może być użyty, system podejmie próbę powrotu do drugiej opcji."
+            "value" : "Podaż insuliny jest ustalana dzięki pobieraniu danych z pompy. Może się to odbywać na dwa sposoby: poprzez interpretację historii zdarzeń lub poprzez porównywanie objętości zbiornika na insulinę w czasie. Interpretacja historii zdarzeń pozwala na dokładniejsze odwzorowanie wykresu statusu i wysyłanie aktualnych danych dotyczących leczenia do Nightscouta. Odbywa się to kosztem szybszego zużycia baterii i większym ryzykiem błędu transmisji radiowej względem drugiego sposobu, czyli porównywania objętości zbiornika na insulinę w czasie. Jeśli wybrany sposób z jakiegoś powodu nie może być użyty, system podejmie próbę powrotu do drugiej opcji."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin delivery can be determined from the pump by either interpreting the event history or comparing the reservoir volume over time. Reading event history allows for a more accurate status graph and uploading up-to-date treatment data to Nightscout, at the cost of faster pump battery drain and the possibility of a higher radio error rate compared to reading only reservoir volume. If the selected source cannot be used for any reason, the system will attempt to fall back to the other option."
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "A quantidade de insulina utilizada pode ser determinada tanto interpretando o histórico de eventos quanto medindo a diferença no volume do reservatório. Ler a partir do histórico de eventos permite um gráfico de estado mais preciso e o envio de dados de tratamento mais atualizados para o Nightscout, mas com um maior gasto de bateria e com uma maior possibilidade de erros de transmissão, quando comparado com a leitura apenas do volume do reservatório. Se a fonte selecionada não puder ser utilizada por algum motivo, o sistema tentará a outra opção."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Livrarea insulinei poate fi determinată din interpretarea istoricului citit din pompă sau analizând nivelul rezervorului în timp. Citirea istoricului de evenimente permite o construcție mai exacta a graficului și uploadarea datelor actualizate în Nightscout cu prețul descărcării mai rapide a bateriei pompei si a probabilității mai mari de erori de transmisie radio, comparând cu citire numai a nivelului rezervorului. Dacă dintr-o cauză sau alta sistemul nu va reuși să folosească opțiunea aleasă, se va încerca revenirea la cealaltă posibilitate."
           }
         },
         "ru" : {
@@ -3888,7 +4896,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin delivery can be determined from the pump by either interpreting the event history or comparing the reservoir volume over time. Reading event history allows for a more accurate status graph and uploading up-to-date treatment data to Nightscout, at the cost of faster pump battery drain and the possibility of a higher radio error rate compared to reading only reservoir volume. If the selected source cannot be used for any reason, the system will attempt to fall back to the other option."
+            "value" : "Mängd doserat insulin kan bestämmas antingen genom att tolka händelsehistoriken från pumpen eller genom att jämföra reservoarvolymen över tid. Att läsa av händelsehistoriken tillåter ett mer korrekt statusdiagram och mer aktuella behandlingsdata för uppladdning till Nightscout, men laddar ur batteriet snabbare och ökar risken för andel eventuella radiofel jämfört med avläsning av endast reservoarvolym. Om det ena alternativet av någon anledning inte kan användas, försöker systemet med det andra alternativet."
           }
         },
         "tr" : {
@@ -3897,10 +4905,22 @@
             "value" : "İnsülin iletimi, olay geçmişi yorumlanarak veya zaman içindeki rezervuar hacmi karşılaştırılarak pompadan belirlenebilir. Olay geçmişinin okunması, daha doğru bir durum grafiğine ve Nightscout'a güncel tedavi verilerinin yüklenmesine izin verir, bu da sadece rezervuar hacmini okumaya kıyasla daha hızlı pompa pili tüketimi ve daha yüksek bir radyo hatası olasılığına sebep olur. Seçilen kaynak herhangi bir nedenle kullanılamıyorsa sistem diğer seçeneğe geri dönmeye çalışacaktır."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подача інсуліну може визначатися з помпи шляхом інтерпретації історії подій чи порівнянням зміни обсягів резервуара за час. Читання історії подій дозволяє викреслити більш точний графік стану та завантажити в Nightscout актуальні дані лікування/призначень (за рахунок швидшого виснаження батареї помпи та вищого відсотка помилок радіозв'язку) порівняно зі зчитуванням даних лише про обсяг резервуара."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Việc tiêm insulin có thể được quyết định từ bơm bằng cách kết hợp giải thuật dữ liệu của người sử dụng và so sánh với khối lượngngăn chứa insulin theo thời gian. Việc đọc các dữ liệu cũ sẽ đảm bảo biểu đồ đường huyết luôn được tính chính xác và tải dữ liệu điều trị cập nhật lên Nightscout, nhưng lại tăng việc tiêu hao pin cũng như lỗi giao tiếp tần số radio cao hơn việc chỉ đọc mỗi dữ liệu ngăn chứa insulin. Trong trường hợp nguồn dữ liệu không được lựa chọn vì bất kỳ lý do gì thì phần mềm sẽ quay sang lựa chọn khác."
+            "value" : "Việc tiêm insulin có thể được quyết định từ bơm bằng cách kết hợp giải thuật dữ liệu của người sử dụng và so sánh với khối lượng ngăn chứa insulin theo thời gian. Việc đọc các dữ liệu cũ sẽ đảm bảo biểu đồ đường huyết luôn được tính chính xác và tải dữ liệu điều trị cập nhật lên Nightscout, nhưng lại tăng việc tiêu hao pin cũng như lỗi giao tiếp tần số radio cao hơn việc chỉ đọc mỗi dữ liệu ngăn chứa insulin. Trong trường hợp nguồn dữ liệu không được lựa chọn vì bất kỳ lý do gì thì phần mềm sẽ quay sang lựa chọn khác."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin delivery can be determined from the pump by either interpreting the event history or comparing the reservoir volume over time. Reading event history allows for a more accurate status graph and uploading up-to-date treatment data to Nightscout, at the cost of faster pump battery drain and the possibility of a higher radio error rate compared to reading only reservoir volume. If the selected source cannot be used for any reason, the system will attempt to fall back to the other option."
           }
         },
         "zh-Hans" : {
@@ -3914,16 +4934,16 @@
     "Insulin Remaining" : {
       "comment" : "Header for insulin remaining on pod settings screen",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zbývající inzulín"
+            "value" : "الأنسولين المتبقي"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin tilbage"
+            "value" : "Resterende Insulin"
           }
         },
         "de" : {
@@ -3938,6 +4958,12 @@
             "value" : "Insulina restante"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Remaining"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3946,44 +4972,56 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "אינסולין שנותר"
+            "state" : "new",
+            "value" : "Insulin Remaining"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Remaining"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina rimanente"
+            "value" : "Insulina Rimanente"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gjenværende insulin"
+            "value" : "Insulin i pod"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Resterende Insuline"
+            "value" : "Resterende insuline"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pozostała ilość insuliny"
+            "state" : "new",
+            "value" : "Insulin Remaining"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulină rămasă"
+            "state" : "new",
+            "value" : "Insulin Remaining"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Remaining"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Остаток инсулина"
+            "value" : "Осталось инсулина"
           }
         },
         "sk" : {
@@ -3992,10 +5030,40 @@
             "value" : "Zostávajúci inzulín"
           }
         },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insulin kvar"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kalan İnsülin"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Залишок Інсуліну"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insulin còn lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Remaining"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "胰岛素余量"
           }
         }
       }
@@ -4003,10 +5071,10 @@
     "Insulin Type" : {
       "comment" : "Text for confidence reminders navigation link",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Typ inzulínu"
+            "value" : "نوع الإنسولين"
           }
         },
         "da" : {
@@ -4018,7 +5086,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulintyp"
+            "value" : "Insulin Typ"
           }
         },
         "es" : {
@@ -4029,29 +5097,35 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insuliinityyppi"
+            "state" : "new",
+            "value" : "Insulin Type"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Type d'insuline"
+            "value" : "Type d'Insuline"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "סוג אינסולין"
+            "state" : "new",
+            "value" : "Insulin Type"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tipo d'insulina"
+            "value" : "Tipo di Insulina"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulintype"
@@ -4060,19 +5134,25 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinetype"
+            "value" : "Insulinesoort"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rodzaj insuliny"
+            "state" : "new",
+            "value" : "Insulin Type"
           }
         },
-        "ro" : {
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type"
+          }
+        },
+        "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tipul de insulină"
+            "value" : "Tipo de Insulina"
           }
         },
         "ru" : {
@@ -4084,13 +5164,13 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Typ inzulínu"
+            "value" : "Typ Inzulínu"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulintyp"
+            "value" : "Typ av insulin"
           }
         },
         "tr" : {
@@ -4098,13 +5178,37 @@
             "state" : "translated",
             "value" : "İnsülin Tipi"
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тип Інсуліну"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loại Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "胰岛素类型"
+          }
         }
       }
     },
     "Medtronic %1$@" : {
       "comment" : "Format string fof navigation bar title for MinimedPumpSettingsView (1: model number)",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Medtronic %1$@"
@@ -4128,6 +5232,12 @@
             "value" : "Medtronic %1$@"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medtronic %1$@"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4136,8 +5246,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medtronic"
+            "state" : "new",
+            "value" : "Medtronic %1$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medtronic %1$@"
           }
         },
         "it" : {
@@ -4146,7 +5262,7 @@
             "value" : "Medtronic %1$@"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Medtronic %1$@"
@@ -4160,13 +5276,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Medtronic %1$@"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Medtronic %1$@"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Medtronic %1$@"
           }
         },
@@ -4176,9 +5298,45 @@
             "value" : "Medtronic %1$@"
           }
         },
-        "tr" : {
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Medtronic %1$@"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medtronic %1$@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medtronic %1$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medtronic %1$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medtronic %1$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medtronic %1$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Medtronic %1$@"
           }
         }
@@ -4187,16 +5345,16 @@
     "Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models." : {
       "comment" : "Instructions on selecting setting for MySentry",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Modely pump Medtronic 523, 723, 554 a 754 mají funkci nazvanou „MySentry“, která periodicky vysílá stav baterie v zásobníku v pumpě. Příjem těchto vysílání umožňuje Loopu komunikovat s pumpou méně často, což může prodloužit životnost baterie pumpy. Při použití této funkce však RileyLink zůstává více času vzhůru a využívá více vlastní baterie. Povolení může prodloužit životnost baterie pumpy, zatímco její zakázání může prodloužit životnost baterie RileyLink. Toto nastavení je u ostatních modelů pump ignorováno."
+            "value" : "تتمتع مضخات Medtronic من الطرازات 523 و723 و554 و754 بميزة تُدعى \"MySentry\" التي تقوم بشكل دوري ببث مستويات الخزان والبطارية للمضخة. الاستماع لهذه البثوث يسمح لنظام Loop بالتواصل مع المضخة بشكل أقل تكرارًا، مما يمكن أن يزيد من عمر بطارية المضخة. ومع ذلك، عند استخدام هذه الميزة، تظل RileyLink متيقظة لفترات أطول وتستخدم المزيد من بطاريتها الخاصة. تفعيل هذه الميزة قد يطيل عمر بطارية المضخة، بينما تعطيلها قد يطيل عمر بطارية RileyLink. يتم تجاهل هذا الإعداد بالنسبة لطرازات المضخات الأخرى."
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Medtronic-pumpe-modellerne 523, 723, 554 og 754 har en funktion kaldet \"MySentry\", der regelmæssigt sender batteriniveauet for reservoiret og pumpen. Ved at lytte til disse udsendelser kan Loop kommunikere mindre hyppigt med pumpen, hvilket kan forlænge pumpens batterilevetid. Når denne funktion anvendes, forbliver RileyLink dog vågen i længere tid og bruger mere af sit eget batteri. Hvis du aktiverer denne funktion, kan pumpens batterilevetid forlænges, mens du deaktiverer den kan forlænge RileyLink-batteriets levetid. Denne indstilling ignoreres for andre pumpemodeller."
+            "value" : "Medtronic-pumpemodellerne 523, 723, 554 og 754 har en funktion kaldet \"MySentry\", der periodisk sender batteriniveauet for reservoir og pumpe. Ved at lytte efter disse udsendelser kan Loop kommunikere mindre hyppigt med pumpen, hvilket kan forlænge pumpens batterilevetid. Når denne funktion anvendes, forbliver RileyLink dog vågen i længere tid og bruger mere af sit eget batteri. Aktiveres denne funktion, kan pumpens batteritid forlænges, mens RileyLink-batteritiden kan forlænges, hvis den deaktiveres. Indstillingen ignoreres for andre pumpemodeller."
           }
         },
         "de" : {
@@ -4211,6 +5369,12 @@
             "value" : "Los modelos de bomba Medtronic 523, 723, 554 y 754 tienen una función llamada 'MySentry' que transmite periódicamente los niveles de la batería y del del depósito de la bomba. Escuchar estas transmisiones permite que Loop se comunique con la bomba con menos frecuencia, lo que puede aumentar la duración de la batería de la bomba. Sin embargo, cuando se usa esta función, el RileyLink permanece despierto la mayor parte del tiempo y usa más de su propia batería. Habilitar esto puede prolongar la duración de la batería de la bomba, mientras que deshabilitarlo puede prolongar la duración de la batería de RileyLink. Este ajuste se ignora para otros modelos de bomba."
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models."
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4219,17 +5383,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "דגמי משאבת Medtronic מספר 523, 554, 723 ו-754 תומכות ב-MySentry: אפשרות לשדר מדי פעם את האינסולין שנותר במשאבה ומידע על הסוללה. Loop יכול להאזין לשידורים אלה כדי לתקשר פחות עם המשאבה, ולהאריך לה את זמן הסוללה. עם זאת, RileyLink יישאר ער זמן רב יותר וזמן הסוללה שלו יתקצר. הפעלה של MySentry מאריכה את זמן הסוללה במשאבה וביטול שלה מאריכה את זמן הסוללה ב-Rileylink. הגדרה זו לא בשימוש בכל משאבה/דגם אחר."
+            "state" : "new",
+            "value" : "Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "I modelli di pompa Medtronic 523, 723, 554 e 754 dispongono di una funzione denominata \"MySentry\" che trasmette periodicamente i livelli della batteria del serbatoio e della pompa. L'ascolto di queste trasmissioni consente a Loop di comunicare meno frequentemente con la pompa, il che può aumentare la durata della batteria della pompa. Tuttavia, quando si utilizza questa funzione, RileyLink rimane attivo per la maggior parte del tempo e utilizza più batteria. Abilitare questa opzione può allungare la durata della batteria della pompa, mentre disabilitarla può allungare la durata della batteria di RileyLink. Questa impostazione viene ignorata per altri modelli di pompa."
+            "value" : "I modelli di pompa Medtronic 523, 723, 554 e 754 dispongono di una funzione denominata \"MySentry\" che trasmette periodicamente i livelli della batteria del serbatoio e della pompa. L'ascolto di queste trasmissioni consente a Loop di comunicare meno frequentemente con il microinfusore, il che può aumentare la durata della batteria del microinfusore. Tuttavia, quando si utilizza questa funzione, RileyLink rimane sveglio per la maggior parte del tempo e utilizza più della propria batteria. Abilitare questa opzione può allungare la durata della batteria della pompa, mentre disabilitarla può allungare la durata della batteria di RileyLink. Questa impostazione viene ignorata per altri modelli di pompa."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Medtronic-pumpemodellene 523, 723, 554 og 754 har en funksjon kalt 'MySentry' som med jevne mellomrom kringkaster reservoar- og pumpebatterinivåene. Når du lytter til disse sendingene, kan Loop kommunisere med pumpen sjeldnere, noe som kan øke pumpens batterilevetid. Men når du bruker denne funksjonen, holder RileyLink seg våken mer av tiden og bruker mer av sitt eget batteri. Aktivering av dette kan forlenge pumpens batterilevetid, mens deaktivering kan forlenge RileyLink-batteriets levetid. Denne innstillingen ignoreres for andre pumpemodeller."
@@ -4247,10 +5417,16 @@
             "value" : "Modele pomp firmy Medtronic 523, 723, 554 i 754 są wyposażone w funkcję o nazwie „MySentry”, która okresowo wysyła informacje o stanie baterii i poziomie w zbiorniczku pompy. Odbiór tych informacji pozwala Loop na rzadszą komunikację z pompą, co może wydłużyć żywotność baterii pompy. Jednak podczas korzystania z tej funkcji RileyLink pracuje przez większą część czasu i zużywa więcej własnej baterii. Włączenie tej opcji może wydłużyć żywotność baterii pompy, a jej wyłączenie może wydłużyć żywotność baterii RileyLink. To ustawienie jest ignorowane w przypadku innych modeli pomp."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelele de pompe Medtronic 523, 723, 554 și 754 au o funcție numită \"MySentry\" care transmite periodic nivelul rezervorului și al bateriei pompei. Ascultarea acestor transmisiuni permite ca Loop să comunice mai rar cu pompa, ceea ce poate crește durata de viață a bateriei pompei. Cu toate acestea, atunci când se utilizează această funcție, RileyLink rămâne treaz mai mult timp și utilizează mai mult din propria baterie. Activarea acestei funcții poate prelungi durata de viață a bateriei pompei, în timp ce dezactivarea acesteia poate prelungi durata de viață a bateriei RileyLink. Această setare este ignorată pentru alte modele de pompe."
+            "state" : "new",
+            "value" : "Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models."
           }
         },
         "ru" : {
@@ -4262,7 +5438,13 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Modely pumpy Medtronic 523, 723, 554 a 754 majú funkciu s názvom „MySentry“, ktorá pravidelne vysiela úroveň nabitia batérie zásobníka a pumpy. Počúvanie týchto vysielaní umožňuje Loopu komunikovať s pumpou menej často, čo môže predĺžiť výdrž batérie pumpy. Pri používaní tejto funkcie však RileyLink zostáva viac času v bdelom stave a využíva viac vlastnej batérie. Povolenie môže predĺžiť životnosť batérie pumpy, zatiaľ čo jej vypnutie môže predĺžiť životnosť batérie RileyLink. Toto nastavenie sa pri iných modeloch čerpadiel ignoruje."
+            "value" : "Modely inzulínových púmp Medtronic 523, 723, 554 a 754 majú funkciu „MySentry“, ktorá pravidelne vysiela informácie o stave zásobníka a batérie pumpy. Počúvaním týchto vysielaní môže Loop komunikovať s pumpou menej často, čo môže predĺžiť životnosť batérie pumpy. Avšak pri použití tejto funkcie zostáva RileyLink aktívny dlhší čas, čo znamená vyššiu spotrebu jeho vlastnej batérie. Zapnutie tejto funkcie môže predĺžiť životnosť batérie pumpy. Vypnutie môže predĺžiť výdrž batérie RileyLink. Toto nastavenie sa ignoruje pri iných modeloch púmp."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modellerna 523, 723, 554 och 754 från Medtronic har en funktion som kallas MySentry, som regelbundet övervakar reservoar- och pumpbatterinivåer. Genom att lyssna efter dessa sändningar kan iAPS kommunicera med pumpen mindre ofta, vilket kan öka pumpens batteritid. Men när du använder den här funktionen kommer  RileyLink att vara vaken oftare vilket använder mer av sitt eget batteri. Aktivering av detta kan förlänga pumpens batteritid, medan inaktivera det kan förlänga RileyLink-batteriets livslängd. Denna inställning ignoreras för andra pumpmodeller."
           }
         },
         "tr" : {
@@ -4271,10 +5453,28 @@
             "value" : "Medtronic pompa modelleri 523, 723, 554 ve 754, rezervuar ve pompa pil seviyelerini periyodik olarak yayınlayan 'MySentry' adlı bir özelliğe sahiptir. Bu yayınların dinlenmesi, Loop'un pompayla daha az iletişim kurmasını sağlayarak pompanın pil ömrünü uzatabilir. Ancak, bu özelliği kullanırken, RileyLink daha çok uyanık kalır ve kendi pilinden daha fazla tüketir. Bunun etkinleştirilmesi pompa pil ömrünü uzatabilir, devre dışı bırakılması ise RileyLink pil ömrünü uzatabilir. Bu ayar, diğer pompa modelleri için dikkate alınmaz."
           }
         },
-        "zh-Hans" : {
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "敦力胰岛素泵型号 523、723、554 和 754 具备一项名为 “MySentry” 的功能，会定期广播储液器余量和电池电量信息。\nLoop 监听这些广播后，可以减少与胰岛素泵的直接通信频率，从而延长胰岛素泵的电池寿命。\n\n但与此同时，RileyLink 需要更长时间保持唤醒状态，这会导致它自身的电池消耗增加。\n\n启用此功能可能有助于延长泵的电池寿命，而禁用则可能有助于延长 RileyLink 的电池寿命。\n对于其他型号的胰岛素泵，此设置将被忽略。"
+            "value" : "Моделі помпи Medtronic 523, 723, 554 та 754 мають функцію MySentry, яка періодично передає дані про рівень заряду батареї в резервуарі та помпі. Прослуховування цих передач дозволяє Loop рідше зв'язуватися з насосом, що може збільшити термін служби батареї насоса. Однак при використанні цієї функції RileyLink довше не спить та використовує більше власної батареї. Увімкнення цього параметра може збільшити термін служби батареї насоса, а його вимкнення може продовжити термін служби батареї RileyLink. Цей параметр ігнорується для інших моделей помп."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Các mẫu máy bơm Medtronic 523, 723, 554 và 754 có một tính năng gọi là 'MySentry', phát sóng định kỳ mức pin của bình chứa và máy bơm. Việc lắng nghe các chương trình phát sóng này cho phép Loop liên lạc với máy bơm ít thường xuyên hơn, điều này có thể tăng tuổi thọ pin của máy bơm. Tuy nhiên, khi sử dụng tính năng này, RileyLink sẽ hoạt động lâu hơn và sử dụng nhiều pin hơn. Việc bật tính năng này có thể kéo dài tuổi thọ pin của máy bơm, trong khi việc tắt tính năng này có thể kéo dài tuổi thọ pin RileyLink. Cài đặt này bị bỏ qua đối với các kiểu máy bơm khác."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models."
           }
         }
       }
@@ -4282,10 +5482,10 @@
     "No" : {
       "comment" : "Value string for MySentry config when MySentry is not being used",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ne"
+            "value" : "لا"
           }
         },
         "da" : {
@@ -4306,6 +5506,12 @@
             "value" : "No"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ei"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4314,8 +5520,14 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "לא"
+            "value" : "Nem"
           }
         },
         "it" : {
@@ -4324,7 +5536,7 @@
             "value" : "No"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nei"
@@ -4338,14 +5550,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie"
+            "state" : "new",
+            "value" : "No"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu"
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
           }
         },
         "ru" : {
@@ -4360,10 +5578,40 @@
             "value" : "Nie"
           }
         },
-        "tr" : {
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hayır"
+            "value" : "Nej"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ні"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
           }
         }
       }
@@ -4371,10 +5619,10 @@
     "No response" : {
       "comment" : "Message display when no response from tuning pump",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Žádná odpověď"
+            "value" : "لا يوجد استجابة"
           }
         },
         "da" : {
@@ -4409,8 +5657,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "אין תגובה"
+            "state" : "new",
+            "value" : "No response"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No response"
           }
         },
         "it" : {
@@ -4419,13 +5673,7 @@
             "value" : "Nessuna risposta"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "反応なし"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ingen svar"
@@ -4443,22 +5691,28 @@
             "value" : "Brak odpowiedzi"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No response"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sem Resposta"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Niciun răspuns"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Нет ответа"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Žiadna odpoveď"
           }
         },
         "sv" : {
@@ -4473,10 +5727,22 @@
             "value" : "Cevap yok"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Немає відповіді"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Không có phản hồi nào"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No response"
           }
         },
         "zh-Hans" : {
@@ -4490,10 +5756,10 @@
     "No, Keep Pump As Is" : {
       "comment" : "Button text to cancel pump time sync",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ne, ponechat pumpu tak, jak je"
+            "value" : "لا، إبقاء المضخة كما هي"
           }
         },
         "da" : {
@@ -4505,13 +5771,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nein, Pumpe so lassen wie sie ist"
+            "value" : "Nein, Pumpe unverändert behalten"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "No, mantenga la bomba como está"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
           }
         },
         "fr" : {
@@ -4522,17 +5794,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "לא, השאר משאבה כפי שהיא"
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No, mantieni la pompa così com'è"
+            "value" : "No, Tieni microinfusore Come È"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nei, behold pumpen som den er"
@@ -4541,31 +5819,73 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nee, laat de pomp ongewijzigd"
+            "value" : "Nee, pomp laten zoals hij is"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie, pozostaw bez zmian"
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu, păstrați pompa așa cum este"
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Нет, оставить время в помпе как есть"
+            "value" : "Нет, оставить как есть"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie, nechajte pumpu tak, ako je"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nej, behåll pumptid"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hayır, Pompayı Olduğu Gibi Tutun"
+            "value" : "Hayır güncelleme"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ні, залишити  як є"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không, Giữ nguyên"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
           }
         }
       }
@@ -4573,10 +5893,10 @@
     "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device" : {
       "comment" : "Pump find device instruction",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Na pumpě přejděte na obrazovku Najít zařízení a vyberte „Najít zařízení“. \n\n Hlavní nabídka >\n Utility >\n Připojit zařízení >\n Ostatní zařízení >\n Zapnuto >\n Najít zařízení"
+            "state" : "new",
+            "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
         "da" : {
@@ -4587,13 +5907,13 @@
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
@@ -4605,7 +5925,7 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
@@ -4615,21 +5935,21 @@
             "value" : "במשאבה שלך, מצא את מסך \"Find Device״ ולחץ עליו.\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sulla pompa, vai alla schermata Trova dispositivo e seleziona \"Trova dispositivo\". \n\nMenu principale > \nUtilità > \nConnetti dispositivi > \nAltri dispositivi > \nAttivato > \nTrova dispositivo"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプの Find Device 画面で「Find Device」を選択します。\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
@@ -4645,16 +5965,16 @@
             "value" : "W pompie przejdź do ekranu Znajdź urządzenie i wybierz opcję „Znajdź urządzenie”.\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Na sua Bomba, vá para a tela de encontrar dispositivos (Find Device) e selecione \"Encontrar Dispositivo\" (Find Device).\n\nMenu Principal >\nUtilitários (Utilities) >\nConectar Dispositivos (Connect Devices)\nOutros Dispositivos (Other Devices) >\nLigar (On) >\nEncontrar Dispositivo (Find Device)"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pe pompa, mergeți la ecranul \"Find Device\" și selectați \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
         "ru" : {
@@ -4672,7 +5992,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
+            "value" : "På din pump, gå till skärmen 'Hitta enhet' och välj 'Hitta enhet'.\n\nHuvudmeny >\nTillbehör >\nAnslut enheter >\nAndra enheter >\nPå >\nHitta enhet"
           }
         },
         "tr" : {
@@ -4681,15 +6001,27 @@
             "value" : "Pompanızda Cihaz Bul ekranına gidin ve \"Cihaz Bul\" öğesini seçin.\n\nAna Menü >\nAraçlar>\nCihazları Bağlayın >\nDiğer cihazlar >\nAçık >\nCihaz Bul"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
+          }
+        },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         }
@@ -4698,16 +6030,16 @@
     "Preferred Data Source" : {
       "comment" : "Text for medtronic pump preferred data source\nnavigation title for pump battery type selection",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Preferovaný zdroj dat"
+            "value" : "مصدر البيانات المفضل"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Foretruken data kilde"
+            "value" : "Foretrukket datakilde"
           }
         },
         "de" : {
@@ -4736,23 +6068,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מקור מידע מועדף"
+            "state" : "new",
+            "value" : "Preferred Data Source"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preferred Data Source"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fonte dati preferita"
+            "value" : "Fonte Dati"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "推奨データソース"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Foretrukken datakilde"
@@ -4761,7 +6093,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voorkeur Gegevensbron"
+            "value" : "Voorkeur gegevensbron"
           }
         },
         "pl" : {
@@ -4770,22 +6102,28 @@
             "value" : "Preferowane źródło danych"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preferred Data Source"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fonte de Dados Preferido"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sursa de date preferată"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Предпочтительный источник данных"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preferovaný zdroj údajov"
           }
         },
         "sv" : {
@@ -4800,10 +6138,22 @@
             "value" : "Tercih Edilen Veri Kaynağı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Бажане джерело даних"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nguồn dữ liệu được ưa thích"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preferred Data Source"
           }
         },
         "zh-Hans" : {
@@ -4817,16 +6167,16 @@
     "Pump Battery Remaining" : {
       "comment" : "Text for medtronic pump battery percent remaining",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zbývající kapacita baterie pumpy"
+            "value" : "الوقت المتبقي لبطارية المضخة"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Resterende batteri i pumpen"
+            "value" : "Resterende pumpebatteri"
           }
         },
         "de" : {
@@ -4835,25 +6185,43 @@
             "value" : "Verbleibende Pumpenbatterie"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batería restante de la bomba"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Remaining"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batterie de la pompe restante"
+            "value" : "Batterie Pompe restante"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "סוללת משאבה שנותרה"
+            "state" : "new",
+            "value" : "Pump Battery Remaining"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Remaining"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batteria della pompa rimanente"
+            "value" : "Batteria Pompa Rimanente"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gjenværende pumpebatteri"
@@ -4862,7 +6230,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pompbatterij Resterend"
+            "value" : "Pompbatterij resterend"
           }
         },
         "pl" : {
@@ -4871,10 +6239,16 @@
             "value" : "Kondycja baterii"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nivel baterie pompă"
+            "state" : "new",
+            "value" : "Pump Battery Remaining"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Remaining"
           }
         },
         "ru" : {
@@ -4883,16 +6257,46 @@
             "value" : "Оставшийся заряд батареи помпы"
           }
         },
-        "tr" : {
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kalan Pompa Pili"
+            "value" : "Zostávajúca batéria pumpy"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpbatteri kvar"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Remaining"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Заряд батареї помпи, що залишився"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin còn lại của Bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Remaining"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "泵电量"
+            "state" : "new",
+            "value" : "Pump Battery Remaining"
           }
         }
       }
@@ -4900,16 +6304,16 @@
     "Pump Battery Type" : {
       "comment" : "Text for medtronic pump battery type\nnavigation title for pump battery type selection",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Typ baterie pumpy"
+            "value" : "نوع بطارية المضخة"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pumpe batteritype"
+            "value" : "Pumpebatteritype"
           }
         },
         "de" : {
@@ -4938,23 +6342,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "סוג סוללת משאבה"
+            "state" : "new",
+            "value" : "Pump Battery Type"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Type"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tipo batteria pompa"
+            "value" : "Tipo Batteria Microinfusore"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプの電池の種類"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Type pumpebatteri"
@@ -4972,22 +6376,28 @@
             "value" : "Rodzaj baterii w pompie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Type"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tipo de Bateria da Bomba"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipul bateriei pompei"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Тип батарейки в помпе"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ batérie pumpy"
           }
         },
         "sv" : {
@@ -5002,10 +6412,22 @@
             "value" : "Pompa Pil Tipi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тип батареї помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Loại pin của bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Type"
           }
         },
         "zh-Hans" : {
@@ -5022,13 +6444,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pump ID"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID pumpy"
+            "value" : "ID المضخة"
           }
         },
         "da" : {
@@ -5064,22 +6480,22 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "מספר זיהוי משאבה"
+            "value" : "מספר זיהוי המשאבה"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump ID"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ID pompa"
+            "value" : "ID microinfusore"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプ ID"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpe ID"
@@ -5097,16 +6513,16 @@
             "value" : "ID pompy"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump ID"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ID da Bomba"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ID pompă"
           }
         },
         "ru" : {
@@ -5133,10 +6549,22 @@
             "value" : "Pompa Kimliği"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Số ID của bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump ID"
           }
         },
         "zh-Hans" : {
@@ -5150,10 +6578,10 @@
     "Pump Time" : {
       "comment" : "The title of the command to change pump time zone",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Čas pumpy"
+            "value" : "وقت المضخة"
           }
         },
         "da" : {
@@ -5165,13 +6593,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Uhrzeit der Pumpe"
+            "value" : "Pumpenzeit"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hora de la bomba"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Time"
           }
         },
         "fr" : {
@@ -5182,20 +6616,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "שעה במשאבה"
+            "state" : "new",
+            "value" : "Pump Time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Time"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Orario pompa"
+            "value" : "Orario del microinfusore"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pumpetid"
+            "value" : "Pumpe-tid"
           }
         },
         "nl" : {
@@ -5206,20 +6646,38 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czas pompy"
+            "state" : "new",
+            "value" : "Pump Time"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ora pompei"
+            "state" : "new",
+            "value" : "Pump Time"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Time"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Время в помпе"
+            "value" : "Время помпы"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Čas pumpy"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumptid"
           }
         },
         "tr" : {
@@ -5228,10 +6686,28 @@
             "value" : "Pompa Zamanı"
           }
         },
-        "zh-Hans" : {
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "泵时间"
+            "value" : "Час помпи"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thời gian của Bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Time"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Time"
           }
         }
       }
@@ -5239,16 +6715,16 @@
     "Reading basal schedule…" : {
       "comment" : "Progress message for reading basal schedule",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Čtení bazálního rozvrhu…"
+            "value" : "قراءة جدول الجرعة الأساسية…"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Læser basal-plan..."
+            "value" : "Læser basal-tidsplan…"
           }
         },
         "de" : {
@@ -5277,8 +6753,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "קורא תכנון בזאלי…"
+            "state" : "new",
+            "value" : "Reading basal schedule…"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reading basal schedule…"
           }
         },
         "it" : {
@@ -5287,13 +6769,7 @@
             "value" : "Lettura programma basale…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎パターンを読んでいます ..."
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Leser basalplan…"
@@ -5311,22 +6787,28 @@
             "value" : "Sprawdzanie dawki podstawowej…"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reading basal schedule…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lendo programação de basal…"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se citește programul bazalelor…"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Чтение графика базала…"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Načítava sa rozvrh bazálu…"
           }
         },
         "sv" : {
@@ -5341,10 +6823,22 @@
             "value" : "Bazal Programı Okunuyor…"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Читання графіка базалу…"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang đọc lịch biểu liều nền…"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reading basal schedule…"
           }
         },
         "zh-Hans" : {
@@ -5358,16 +6852,16 @@
     "Reading pump status…" : {
       "comment" : "Progress message for reading pump status",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Čtení stavu pumpy…"
+            "value" : "قراءة حالة المضخة…"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Læser pumpestatus..."
+            "value" : "Læser pumpestatus…"
           }
         },
         "de" : {
@@ -5396,23 +6890,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "קורא מצב משאבה…"
+            "state" : "new",
+            "value" : "Reading pump status…"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reading pump status…"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lettura stato pompa…"
+            "value" : "Lettura stato microinfusore…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプの状態を読んでいます ..."
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Leser pumpestatus…"
@@ -5430,22 +6924,28 @@
             "value" : "Sprawdzanie statusu pompy…"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reading pump status…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lendo estado da bomba…"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se citește starea pompei…"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Чтение статуса помпы…"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Načítavam stav pumpy…"
           }
         },
         "sv" : {
@@ -5460,10 +6960,22 @@
             "value" : "Pompa Durumu Okunuyor…"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Читання статусу помпи..."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang đọc tình trạng bơm…"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reading pump status…"
           }
         },
         "zh-Hans" : {
@@ -5477,10 +6989,10 @@
     "Region" : {
       "comment" : "The title of the cell showing the pump region",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oblast"
+            "value" : "المنطقة"
           }
         },
         "da" : {
@@ -5515,23 +7027,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "אזור"
+            "state" : "new",
+            "value" : "Region"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Region"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Region"
+            "value" : "Paese"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "リージョン"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Region"
@@ -5545,7 +7057,13 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Region"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Region"
           }
         },
@@ -5555,16 +7073,16 @@
             "value" : "Região"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Regiune"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Регион"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Región"
           }
         },
         "sv" : {
@@ -5579,15 +7097,27 @@
             "value" : "Bölge"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Регіон"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Khu vực"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Region"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Region"
           }
         }
@@ -5596,10 +7126,10 @@
     "Resume Delivery" : {
       "comment" : "Title text for button to resume insulin delivery",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obnovit podavání"
+            "value" : "استئناف الضخ"
           }
         },
         "da" : {
@@ -5634,8 +7164,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "חדש הזלפה"
+            "state" : "new",
+            "value" : "Resume Delivery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume Delivery"
           }
         },
         "it" : {
@@ -5644,13 +7180,7 @@
             "value" : "Riprendi erogazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "注入を再開"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gjenoppta leveranse"
@@ -5659,7 +7189,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hervat Toediening"
+            "value" : "Hervat toediening"
           }
         },
         "pl" : {
@@ -5668,22 +7198,28 @@
             "value" : "Wznów podawanie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume Delivery"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Retomar Entrega"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reia administrarea"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Возобновить подачу"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obnoviť podávanie inzulínu"
           }
         },
         "sv" : {
@@ -5698,16 +7234,28 @@
             "value" : "İletimi Devam Ettir"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відновити подачу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tiếp tục lại việc tiêm insulin"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume Delivery"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复输注"
+            "state" : "new",
+            "value" : "Resume Delivery"
           }
         }
       }
@@ -5715,10 +7263,10 @@
     "Resuming" : {
       "comment" : "Title text for button when insulin delivery is in the process of being resumed",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obnovování"
+            "value" : "استئناف"
           }
         },
         "da" : {
@@ -5753,8 +7301,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מנסה שוב"
+            "state" : "new",
+            "value" : "Resuming"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resuming"
           }
         },
         "it" : {
@@ -5763,13 +7317,7 @@
             "value" : "Ripresa in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "再開中"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gjenopptar"
@@ -5787,22 +7335,28 @@
             "value" : "Wznawianie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resuming"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Retomando"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se reia"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Возобновляется"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obnovuje sa"
           }
         },
         "sv" : {
@@ -5817,16 +7371,28 @@
             "value" : "Devam ediyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відновлюється"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang tiếp tục lại"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resuming"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复中"
+            "state" : "new",
+            "value" : "Resuming"
           }
         }
       }
@@ -5840,16 +7406,10 @@
             "value" : "أعد المحاولة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zkusit znovu"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Forsøg igen"
+            "value" : "Prøv igen"
           }
         },
         "de" : {
@@ -5866,8 +7426,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yritä uudelleen"
+            "state" : "new",
+            "value" : "Retry"
           }
         },
         "fr" : {
@@ -5878,8 +7438,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "נסה שוב"
+            "state" : "new",
+            "value" : "Retry"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Retry"
           }
         },
         "it" : {
@@ -5888,40 +7454,34 @@
             "value" : "Riprova"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "やり直す"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prøv på nytt"
+            "value" : "Prøv igjen"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Opnieuw Proberen"
+            "value" : "Opnieuw proberen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Spróbuj ponownie"
+            "state" : "new",
+            "value" : "Retry"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Retry"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tentar de Novo"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reîncearcă"
+            "state" : "new",
+            "value" : "Retry"
           }
         },
         "ru" : {
@@ -5945,13 +7505,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yeniden dene"
+            "value" : "Tekrar Dene"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спробувати знову"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thử lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Retry"
           }
         },
         "zh-Hans" : {
@@ -5965,16 +7537,16 @@
     "Scheduled Basal" : {
       "comment" : "Title of insulin delivery section",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Plánovaný bazál"
+            "value" : "الجرعة الأساسية المجدولة"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Planlagt basal"
+            "value" : "Planlagt Basal"
           }
         },
         "de" : {
@@ -5986,13 +7558,13 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina basal programada"
+            "value" : "Basal programada"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ohjelmoitu basaali"
+            "state" : "new",
+            "value" : "Scheduled Basal"
           }
         },
         "fr" : {
@@ -6003,8 +7575,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "בזאלי מתוכנן"
+            "state" : "new",
+            "value" : "Scheduled Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scheduled Basal"
           }
         },
         "it" : {
@@ -6013,13 +7591,7 @@
             "value" : "Basale programmata"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "定期基礎"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Planlagt basal"
@@ -6028,31 +7600,31 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ingesteld Basaal"
+            "value" : "Gepland basaal"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zaplanowana dawka podstawowa"
+            "state" : "new",
+            "value" : "Scheduled Basal"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scheduled Basal"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basal Agendado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazală programată"
+            "state" : "new",
+            "value" : "Scheduled Basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Запланированная база"
+            "value" : "Запланированный Базал"
           }
         },
         "sk" : {
@@ -6070,7 +7642,13 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Programlanan Bazal"
+            "value" : "Programlanmış Bazal"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запланований Базал"
           }
         },
         "vi" : {
@@ -6078,16 +7656,28 @@
             "state" : "translated",
             "value" : "Đã lên chương trình cho liều Basal"
           }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scheduled Basal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预设基础率"
+          }
         }
       }
     },
     "Select the type of insulin that you will be using in this pump." : {
       "comment" : "Title text for insulin type confirmation page",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vyberte typ inzulínu který budete s touto pumpou používat."
+            "value" : "حدد نوع الأنسولين الذي ستستخدمه في هذه المضخة."
           }
         },
         "da" : {
@@ -6099,7 +7689,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wähle die Art des Insulins aus, die Du in dieser Pumpe verwenden möchtest."
+            "value" : "Wählen Sie die Art des Insulins aus, die Sie in dieser Pumpe verwenden möchten."
           }
         },
         "es" : {
@@ -6122,17 +7712,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "בחר את סוג האינסולין שתשתמש בו במשאבה זו."
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Seleziona il tipo d'insulina che utilizzerai in questa pompa."
+            "value" : "Seleziona il tipo di insulina che utilizzerai in questo microinfusore."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velg hvilken type insulin du skal bruke i denne pumpen."
@@ -6150,10 +7746,16 @@
             "value" : "Wybierz rodzaj insuliny, której będziesz używać w pompie."
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selectaţi tipul de insulină pe care o veţi utiliza în această pompă."
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
           }
         },
         "ru" : {
@@ -6179,16 +7781,40 @@
             "state" : "translated",
             "value" : "Bu pompada kullanacağınız insülin tipini seçin."
           }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть тип інсуліну, який ви будете використовувати у цій поспі."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn loại insulin bạn sẽ sử dụng trong máy bơm này."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
+          }
         }
       }
     },
     "Sending button press…" : {
       "comment" : "Progress message for sending button press to pump.",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Odeslání stisknutí tlačítka..."
+            "value" : "الضغط على زر الإرسال…"
           }
         },
         "da" : {
@@ -6223,23 +7849,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "שולח לחיצת כפתור…"
+            "state" : "new",
+            "value" : "Sending button press…"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sending button press…"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Invio del pulsante premuto in corso…"
+            "value" : "Inviando prova pressione pulsante…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボタン押しを送信しています ..."
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sender tastetrykk…"
@@ -6248,7 +7874,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Signaal Druk Op Knop Versturen"
+            "value" : "Signaal 'Druk op knop' versturen"
           }
         },
         "pl" : {
@@ -6257,22 +7883,28 @@
             "value" : "Wysyłanie polecenia wciśnięcia przycisku…"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sending button press…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enviando aperto do botão"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se trimite apăsarea butonului…"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Отправляется команда нажать кнопку…"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odosielanie stlačenie tlačidla…"
           }
         },
         "sv" : {
@@ -6287,10 +7919,22 @@
             "value" : "Gönder butonuna basılıyor…"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відправляється команда нажать кнопку…"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang gửi nút bấm…"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sending button press…"
           }
         },
         "zh-Hans" : {
@@ -6304,10 +7948,10 @@
     "Starting Temp Basal" : {
       "comment" : "Title text for suspend resume button when temp basal starting",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Spustit dočasný bazál"
+            "value" : "بدء الجرعة الأساسية المؤقتة"
           }
         },
         "da" : {
@@ -6342,8 +7986,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מתחיל באזלי זמני"
+            "state" : "new",
+            "value" : "Starting Temp Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Starting Temp Basal"
           }
         },
         "it" : {
@@ -6352,13 +8002,7 @@
             "value" : "Attivazione velocità basale temporanea in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時基礎を開始"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Starter temp-basal"
@@ -6367,7 +8011,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tijdelijk Basaal Starten"
+            "value" : "Tijdelijk basaal starten"
           }
         },
         "pl" : {
@@ -6376,22 +8020,28 @@
             "value" : "Rozpoczynanie tymczasowej dawki podstawowej"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Starting Temp Basal"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Iniciando Temp Basal"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pornire bazală temporară"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Время начала временного базала"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spustiť dočasný bazál"
           }
         },
         "sv" : {
@@ -6406,16 +8056,28 @@
             "value" : "Geçici Bazal başlatılıyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Час початку тимчасового базала"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang bắt đầu liều Basal tạm thời"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Starting Temp Basal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "启动临时寄出"
+            "state" : "new",
+            "value" : "Starting Temp Basal"
           }
         }
       }
@@ -6423,10 +8085,10 @@
     "Succeeded" : {
       "comment" : "A message indicating a command succeeded",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Úspěšně ukončeno"
+            "state" : "new",
+            "value" : "Succeeded"
           }
         },
         "da" : {
@@ -6461,8 +8123,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "בוצע בהצלחה"
+            "state" : "new",
+            "value" : "Succeeded"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Succeeded"
           }
         },
         "it" : {
@@ -6471,13 +8139,7 @@
             "value" : "Effettuato con successo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "成功"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suksess"
@@ -6495,16 +8157,16 @@
             "value" : "Zakończone powodzeniem"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Succeeded"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Completo"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Succes"
           }
         },
         "ru" : {
@@ -6531,10 +8193,22 @@
             "value" : "Başarılı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Успішно"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã thành công"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Succeeded"
           }
         },
         "zh-Hans" : {
@@ -6548,16 +8222,16 @@
     "Suspend Delivery" : {
       "comment" : "Title text for button to suspend insulin delivery",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pozastavit podávání"
+            "value" : "إيقاف التوصيل مؤقتًا"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afbryd insulintilførsel"
+            "value" : "Pause Indgivelse"
           }
         },
         "de" : {
@@ -6581,13 +8255,19 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suspendre l'administration"
+            "value" : "Suspendre la distribution"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "השהה הזלפה"
+            "state" : "new",
+            "value" : "Suspend Delivery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend Delivery"
           }
         },
         "it" : {
@@ -6596,13 +8276,7 @@
             "value" : "Sospendi erogazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "注入を一時停止"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pause leveranse"
@@ -6611,7 +8285,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Onderbreek Toediening"
+            "value" : "Onderbreek toediening"
           }
         },
         "pl" : {
@@ -6620,16 +8294,16 @@
             "value" : "Wstrzymaj podawanie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend Delivery"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suspender Entrega"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspendă administrarea"
           }
         },
         "ru" : {
@@ -6638,10 +8312,16 @@
             "value" : "Остановить подачу"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozastaviť dávkovanie"
+          }
+        },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pausa insulintillförsel"
+            "value" : "Pausa pump"
           }
         },
         "tr" : {
@@ -6650,10 +8330,22 @@
             "value" : "İletimi Askıya Al"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Призупинити Подачу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tạm ngưng liều insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend Delivery"
           }
         },
         "zh-Hans" : {
@@ -6671,12 +8363,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "معلق: %1$@\n"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pozastaveno: %1$@"
           }
         },
         "da" : {
@@ -6715,19 +8401,19 @@
             "value" : "מושהה: %1$@\n"
           }
         },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspended: %1$@\n"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sospeso: %1$@\n"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時停止: %1$@\n"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pauset: %1$@"
@@ -6745,22 +8431,28 @@
             "value" : "Zawieszona: %1$@\n"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspended: %1$@\n"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suspenso: %1$@\n"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspendat: %1$@\n"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Приостановлено: %1$@\n"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspended: %1$@\n"
           }
         },
         "sv" : {
@@ -6775,10 +8467,22 @@
             "value" : "Askıya alındı: %1$@\n"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspended: %1$@\n"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã tạm ngưng: %1$@\n"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspended: %1$@\n"
           }
         },
         "zh-Hans" : {
@@ -6792,10 +8496,10 @@
     "Suspending" : {
       "comment" : "Title text for button when insulin delivery is in the process of being stopped",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pozastavuji"
+            "value" : "تعليق"
           }
         },
         "da" : {
@@ -6830,8 +8534,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מבצע השהייה"
+            "state" : "new",
+            "value" : "Suspending"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspending"
           }
         },
         "it" : {
@@ -6840,13 +8550,7 @@
             "value" : "Sospensione in corso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "一時停止中"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pauser"
@@ -6864,22 +8568,28 @@
             "value" : "Wstrzymywanie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspending"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suspendendo"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se suspendă"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Выполняется остановка"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozastavovanie"
           }
         },
         "sv" : {
@@ -6894,16 +8604,28 @@
             "value" : "Askıya alınıyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виконується зупинка"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang tạm ngưng"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspending"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "正在暂停"
+            "state" : "new",
+            "value" : "Suspending"
           }
         }
       }
@@ -6911,10 +8633,10 @@
     "Sync to Current Time" : {
       "comment" : "The title of the command to change pump time zone",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizovat na aktuální čas"
+            "value" : "المزامنة مع الوقت الحالي"
           }
         },
         "da" : {
@@ -6926,7 +8648,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mit aktueller Uhrzeit synchronisieren."
+            "value" : "Mit aktueller Zeit synchronisieren"
           }
         },
         "es" : {
@@ -6935,25 +8657,37 @@
             "value" : "Sincronizar con la hora actual"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sync to Current Time"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchroniser avec l'heure actuelle"
+            "value" : "Définir sur l'heure actuelle"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "בצע עדכון לשעה הנוכחית"
+            "state" : "new",
+            "value" : "Sync to Current Time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sync to Current Time"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sincronizza con l'orario corrente"
+            "value" : "Sincronizza con l'ora corrente"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Synkroniser til gjeldende tid"
@@ -6967,32 +8701,68 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synchronizuj z bieżącym czasem"
+            "state" : "new",
+            "value" : "Sync to Current Time"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizați cu ora curentă"
+            "state" : "new",
+            "value" : "Sync to Current Time"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sync to Current Time"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронизация с текущим временем"
+            "value" : "Синхронизировать с текущим временем"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronizácia s aktuálnym časom"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synkronisera med aktuell tid"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geçerli Saate Senkronize Et"
+            "value" : "Geçerli Saate Eşitle"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Встановити Поточний Час"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đồng bộ thời gian hiện tại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sync to Current Time"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "同步到当前时间"
+            "state" : "new",
+            "value" : "Sync to Current Time"
           }
         }
       }
@@ -7000,10 +8770,10 @@
     "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?" : {
       "comment" : "Message for pod sync time action sheet",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Čas pumpy se liší od aktuálního času. Chcete aktualizovat čas pumpy na aktuální čas?"
+            "value" : "الوقت في مضختك مختلف عن الوقت الحالي. هل ترغب في تحديث الوقت في مضختك ليتوافق مع الوقت الحالي؟"
           }
         },
         "da" : {
@@ -7015,67 +8785,121 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die Uhrzeit Deiner Pumpe unterscheidet sich von Deiner aktuellen Uhrzeit. Möchtest Du die Uhrzeit Deiner Pumpe auf Deine aktuelle Uhrzeit synchronisieren?"
+            "value" : "Die Zeit Ihrer Pumpe unterscheidet sich von der aktuellen Zeit. Möchten Sie die Pumpenzeit auf die aktuelle Zeit aktualisieren?"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La hora de la bomba es diferente de la hora actual. Desea actualizar la hora de su bomba a la hora actual?"
+            "value" : "La hora de la bomba es diferente de la hora actual. ¿Desea actualizar la hora de su bomba a la hora actual?"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'heure de votre pompe est différente de l'heure actuelle. Voulez vous mettre à jour l'heure de votre pompe avec l'heure actuelle?"
+            "value" : "L'heure de votre pompe est différente de l'heure actuelle. Voulez vous mettre à jour l'heure de votre pompe avec l'heure actuelle ?"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "השעה במשאבה שלך שונה מהשעה הנוכחית. האם ברצונך לעדכן את השעה במשאבה לשעה הנוכחית?"
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'orario indicato sulla pompa è diverso dall'orario attuale. Vuoi aggiornare l'orario indicato sulla pompa con l'orario attuale?"
+            "value" : "L'ora sul microinfusore è diversa dall'ora corrente. Vuoi aggiornare l'ora del microinfusore all'ora corrente?"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Klokken på pumpen er forskjellig fra gjeldende tid. Vil du oppdatere tiden på pumpen til gjeldende tid?"
+            "value" : "Tiden det tar på pumpen er forskjellig fra nåværende tidspunkt. Ønsker du å oppdatere tidspunktet på pumpen til nåværende tidspunkt?"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "De tijd op je pomp is anders dan de huidige tijd. Wil je de tijd op je pomp bijwerken naar de huidige tijd?"
+            "value" : "De pomptijd is anders dan de huidige tijd. Wil je de tijd van je pomp updaten naar de huidige tijd?"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czas na pompie różni się od aktualnego. Czy chcesz zaktualizować czas na pompie?"
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ora de pe pompă este diferită de ora curentă. Puteți revizui ora pompei și să o sincronizați cu ora curentă în meniul setări."
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Время на вашей помпе отличается от текущего времени. Вы хотите обновить время на вашей помпе на текущее?"
+            "value" : "Время на помпе отличается от текущего времени. Обновить время на помпе до текущего времени?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Čas na Vašej pumpe sa líši od aktuálneho času. Chcete aktualizovať čas na vašej pumpe na aktuálny čas?"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tiden på din pump skiljer sig från aktuell tid. Vill du uppdatera tiden på din pump till aktuell tid?"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pompanızdaki saat geçerli saatten farklı. Pompanızdaki saati geçerli saate güncellemek istiyor musunuz?"
+            "value" : "Pompanızdaki saat, mevcut saatten farklı. Pompanızdaki saati şu anki saate güncellemek ister misiniz?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Час на вашій помпі відрізняється від поточного часу. Хочете оновити час на помпі до поточного?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thời gian trên máy bơm của bạn khác với thời gian hiện tại. Bạn có muốn cập nhật thời gian trên máy bơm của mình đến thời điểm hiện tại không?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         }
       }
@@ -7083,10 +8907,10 @@
     "Time Change Detected" : {
       "comment" : "Title for pod sync time action sheet.",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zjištěna změna času"
+            "value" : "تم اكتشاف تغيير في الوقت"
           }
         },
         "da" : {
@@ -7098,7 +8922,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Änderung der Uhrzeit erkannt"
+            "value" : "Zeitänderung erkannt"
           }
         },
         "es" : {
@@ -7107,25 +8931,37 @@
             "value" : "Cambio de hora detectado"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Time Change Detected"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Changement d'heure détecté"
+            "value" : "Changement de temps détecté"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "זוהה שינוי בשעה"
+            "state" : "new",
+            "value" : "Time Change Detected"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Time Change Detected"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rilevato cambio di orario"
+            "value" : "Rilevato Cambio Di Tempo"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tidsendring oppdaget"
@@ -7134,19 +8970,25 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tijdsverschil Ontdekt"
+            "value" : "Wijziging in tijd gedetecteerd"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wykryto zmianę czasu"
+            "state" : "new",
+            "value" : "Time Change Detected"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "S-a detectat schimbarea orei"
+            "state" : "new",
+            "value" : "Time Change Detected"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Time Change Detected"
           }
         },
         "ru" : {
@@ -7161,10 +9003,34 @@
             "value" : "Zistila sa zmena času"
           }
         },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidsjustering upptäckt"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaman Değişikliği Algılandı"
+            "value" : "Zaman Değişikliği Tespit Edildi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виявлено Зміну Часу"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Đã phát hiện thay đổi thời gian"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Time Change Detected"
           }
         },
         "zh-Hans" : {
@@ -7178,10 +9044,10 @@
     "Trials" : {
       "comment" : "The label indicating the results of each frequency trial",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zkoušky"
+            "value" : "تجارب"
           }
         },
         "da" : {
@@ -7216,8 +9082,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ניסיונות"
+            "state" : "new",
+            "value" : "Trials"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Trials"
           }
         },
         "it" : {
@@ -7226,13 +9098,7 @@
             "value" : "Prove"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "トライ"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Forsøk"
@@ -7250,22 +9116,28 @@
             "value" : "Wyniki testu"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Trials"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tentativas"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Încercări"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Попытки"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Testovanie"
           }
         },
         "sv" : {
@@ -7280,10 +9152,22 @@
             "value" : "Denemeler"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Спроби"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Các thử nghiệm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Trials"
           }
         },
         "zh-Hans" : {
@@ -7297,10 +9181,10 @@
     "Tuning radio…" : {
       "comment" : "Progress message for tuning radio",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ladění rádia…"
+            "value" : "ضبط الراديو…"
           }
         },
         "da" : {
@@ -7335,23 +9219,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "מכוון תדר..."
+            "state" : "new",
+            "value" : "Tuning radio…"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tuning radio…"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sintonizzazione radio in corso…"
+            "value" : "Sintonizzazione radio…"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無線を合わせています ..."
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stiller radiofrekvens…"
@@ -7369,22 +9253,28 @@
             "value" : "Dostrajanie radia…"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tuning radio…"
+          }
+        },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sintonizando frequência…"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se ajustează frecvența…"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Настраивается радиочастота…"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Naladenie rádia…"
           }
         },
         "sv" : {
@@ -7399,10 +9289,22 @@
             "value" : "Radyo ayarlanıyor…"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштовується радіочастота."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chuyển tần số radio…"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tuning radio…"
           }
         },
         "zh-Hans" : {
@@ -7422,12 +9324,6 @@
             "value" : "وحدة لكل ساعة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "J/hod"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7437,19 +9333,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "IE/h"
+            "value" : "IE/Std"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/hra"
+            "value" : "U/h"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/h"
+            "state" : "new",
+            "value" : "U/hr"
           }
         },
         "fr" : {
@@ -7460,8 +9356,14 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hr"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "יח׳/שעה"
+            "value" : "U/óra"
           }
         },
         "it" : {
@@ -7470,13 +9372,7 @@
             "value" : "U/ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/時"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "E/t"
@@ -7490,44 +9386,68 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "J/h"
+            "state" : "new",
+            "value" : "U/hr"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hr"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "U/hr"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/oră"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/hr"
+            "value" : "Ед/ч"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "J/hod"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "E/timme"
+            "value" : "IE/h"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ü/sa"
+            "value" : "Ü/Sa"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U/год"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/giờ"
+            "value" : "U/hr"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hr"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U/小时"
           }
         }
       }
@@ -7535,10 +9455,10 @@
     "unknown" : {
       "comment" : "Text to indicate battery percentage is unknown",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Neznámý"
+            "value" : "غير معروف"
           }
         },
         "da" : {
@@ -7553,16 +9473,34 @@
             "value" : "unbekannt"
           }
         },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "desconocido"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "unknown"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inconnu"
+            "value" : "inconnu"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "לא ידוע"
+            "state" : "new",
+            "value" : "unknown"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "unknown"
           }
         },
         "it" : {
@@ -7571,7 +9509,7 @@
             "value" : "sconosciuto"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ukjent"
@@ -7589,10 +9527,16 @@
             "value" : "nieznany"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "necunoscut"
+            "state" : "new",
+            "value" : "unknown"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "unknown"
           }
         },
         "ru" : {
@@ -7601,16 +9545,46 @@
             "value" : "Неизвестно"
           }
         },
-        "tr" : {
+        "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bilinmeyen"
+            "value" : "neznámy"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "okänd"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "unknown"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "невідомий"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "không xác định"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "unknown"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "未知"
+            "state" : "new",
+            "value" : "unknown"
           }
         }
       }
@@ -7620,14 +9594,8 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Unknown"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neznámý"
           }
         },
         "da" : {
@@ -7662,8 +9630,14 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "לא ידוע"
+            "value" : "Ismeretlen"
           }
         },
         "it" : {
@@ -7672,13 +9646,7 @@
             "value" : "Sconosciuto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不明"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukjent"
@@ -7693,19 +9661,19 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nieznany"
+            "value" : "Nieznana"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Desconhecido"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Necunoscut"
           }
         },
         "ru" : {
@@ -7729,13 +9697,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bilinmeyen"
+            "value" : "Bilinmiyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невідомий"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Không nhận ra"
+            "value" : "Không xác định"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown"
           }
         },
         "zh-Hans" : {
@@ -7749,10 +9729,10 @@
     "Use MySentry" : {
       "comment" : "Description for option to use MySentry\nText for medtronic pump to use MySentry\nnavigation title for pump battery type selection",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Použití MySentry"
+            "value" : "استخدام MySentry"
           }
         },
         "da" : {
@@ -7773,6 +9753,12 @@
             "value" : "Usar MySentry"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use MySentry"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7781,8 +9767,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "השתמש ב-MySentry"
+            "state" : "new",
+            "value" : "Use MySentry"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use MySentry"
           }
         },
         "it" : {
@@ -7791,7 +9783,7 @@
             "value" : "Accoppia MySentry"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bruk MySentry"
@@ -7809,10 +9801,16 @@
             "value" : "Użyj MySentry"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utilizați MySentry"
+            "state" : "new",
+            "value" : "Use MySentry"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use MySentry"
           }
         },
         "ru" : {
@@ -7821,16 +9819,46 @@
             "value" : "Использование MySentry"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Použiť MySentry"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Använd MySentry"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "MySentry'yi kullanın"
           }
         },
-        "zh-Hans" : {
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "使用 MySentry"
+            "value" : "Використання MySentry"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sử dụng MySentry"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use MySentry"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use MySentry"
           }
         }
       }
@@ -7838,10 +9866,10 @@
     "Yes" : {
       "comment" : "Value string for MySentry config when MySentry is being used",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ano"
+            "value" : "نعم"
           }
         },
         "da" : {
@@ -7862,6 +9890,12 @@
             "value" : "Sí"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kyllä"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7870,17 +9904,23 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "כן"
+            "value" : "Igen"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "SÌ"
+            "value" : "Sì"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ja"
@@ -7894,14 +9934,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tak"
+            "state" : "new",
+            "value" : "Yes"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da"
+            "state" : "new",
+            "value" : "Yes"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes"
           }
         },
         "ru" : {
@@ -7916,16 +9962,40 @@
             "value" : "Áno"
           }
         },
-        "tr" : {
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Evet"
+            "value" : "Ja"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Có"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "是"
+            "state" : "new",
+            "value" : "Yes"
           }
         }
       }
@@ -7933,16 +10003,16 @@
     "Yes, Sync to Current Time" : {
       "comment" : "Button text to confirm pump time sync",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ano, synchronizovat na aktuální čas"
+            "value" : "نعم، المزامنة مع الوقت الحالي"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, synkroniser til det aktuelle klokkeslæt"
+            "value" : "Ja, synkroniser til aktuel tid"
           }
         },
         "de" : {
@@ -7957,6 +10027,12 @@
             "value" : "Sí, sincronizar con la hora actual"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7965,38 +10041,50 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "כן, סנכרן שעה נוכחית"
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sì, sincronizza con l'orario corrente"
+            "value" : "Sì, sincronizza con l'ora corrente"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, Synkroniser til gjeldende tid"
+            "value" : "Ja, synkroniser til gjeldende tid"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, Synchroniseer met Huidige Tijd"
+            "value" : "Ja, zet naar huidige tijd"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tak, zsynchronizuj z bieżącym czasem"
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, sincronizați cu ora curentă"
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
           }
         },
         "ru" : {
@@ -8005,16 +10093,46 @@
             "value" : "Да, синхронизировать с текущим временем"
           }
         },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Áno, zosynchronizovať s aktuálnym časom"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, synkronisera med aktuell tid"
+          }
+        },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Evet, Geçerli Saatle Senkronize Et"
+            "value" : "Evet güncelle"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, синхронізувати з поточним часом"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Có, đồng bộ với thời gian hiện tại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "是的，同步到当前时间"
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
           }
         }
       }

--- a/MinimedKitUI/Resources/Localizable.xcstrings
+++ b/MinimedKitUI/Resources/Localizable.xcstrings
@@ -10,6 +10,12 @@
             "value" : "%@ ديسيبل"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ dB"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -142,6 +148,12 @@
       "comment" : "Format string for reservoir volume. (1: The localized volume)",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%@U"
@@ -284,6 +296,12 @@
             "value" : "%1$@  %2$@/%3$@  %4$@"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@  %2$@/%3$@  %4$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -421,6 +439,12 @@
             "value" : "%1$@ basal schedule entries\n"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ basal schedule entries\n"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -525,8 +549,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ basal schedule entries\n"
+            "state" : "translated",
+            "value" : "%1$@ записів базального графіка"
           }
         },
         "vi" : {
@@ -553,6 +577,12 @@
       "comment" : "The format string describing units of insulin remaining: (1: number of units)",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ Units of insulin remaining\n"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ Units of insulin remaining\n"
@@ -662,8 +692,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ Units of insulin remaining\n"
+            "state" : "translated",
+            "value" : "Залишилося %1$@ одиниць інсуліну"
           }
         },
         "vi" : {
@@ -690,6 +720,12 @@
       "comment" : "Accessibility format string for (1: localized volume)(2: time)",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@ units remaining at %2$@"
@@ -832,6 +868,12 @@
             "value" : "%1$@%2$@%3$@"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@%3$@"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -967,6 +1009,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "جاري ضبط وقت المضخة..."
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Adjusting Pump Time..."
           }
         },
         "da" : {
@@ -1106,6 +1154,12 @@
             "value" : "البطاريات القلوية والبطاريات الليثيومية تتحلل بمعدلات مختلفة. عادةً ما يكون للبطاريات القلوية انخفاض تدريجي ومستمر في الجهد الكهربائي مع مرور الوقت، بينما تحافظ بطاريات الليثيوم على الجهد الكهربائي حتى تصل إلى منتصف عمرها الافتراضي. في مضخات الأنسولين من طراز Minimed (x22/x15) غير المتوافقة مع MySentry والتي تعمل بنظام Loop، تدوم البطاريات القلوية لمدة تتراوح بين 4 إلى 5 أيام تقريبًا تحت الاستخدام العادي. بينما تدوم بطاريات الليثيوم من أسبوع إلى أسبوعين. سيقوم هذا الاختيار باستخدام معدلات تحلل الجهد المختلفة لكل نوع من أنواع البطاريات وينبه المستخدم عندما تكون البطارية على وشك النفاد، أي قبل حوالي 8 إلى 10 ساعات من الفشل."
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Alkaline and Lithium batteries decay at differing rates. Alkaline tend to have a linear voltage drop over time whereas lithium cell batteries tend to maintain voltage until halfway through their lifespan. Under normal usage in a Non-MySentry compatible Minimed (x22/x15) insulin pump running Loop, Alkaline batteries last approximately 4 to 5 days. Lithium batteries last between 1-2 weeks. This selection will use different battery voltage decay rates for each of the battery chemistry types and alert the user when a battery is approximately 8 to 10 hours from failure."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1241,6 +1295,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "هل أنت متأكد أنك تريد حذف هذه المضخة؟"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to delete this Pump?"
           }
         },
         "da" : {
@@ -1379,6 +1439,12 @@
             "value" : "Battery Chemistry"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery Chemistry"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1483,8 +1549,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery Chemistry"
+            "state" : "translated",
+            "value" : "Хімія (вид) акумуляторів"
           }
         },
         "vi" : {
@@ -1511,6 +1577,12 @@
       "comment" : "The format string describing pump battery voltage: (1: battery voltage)",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery: %1$@ volts\n"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Battery: %1$@ volts\n"
@@ -1620,8 +1692,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery: %1$@ volts\n"
+            "state" : "translated",
+            "value" : "Батарея: %1$@ вольт\n"
           }
         },
         "vi" : {
@@ -1651,6 +1723,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "أفضل تردد"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Best Frequency"
           }
         },
         "da" : {
@@ -1790,6 +1868,12 @@
             "value" : "Bolusing: %1$@\n"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Bolusing: %1$@\n"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1894,8 +1978,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Bolusing: %1$@\n"
+            "state" : "translated",
+            "value" : "Болюс: %1$@\n"
           }
         },
         "vi" : {
@@ -1925,6 +2009,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إلغاء"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
           }
         },
         "da" : {
@@ -2064,6 +2154,12 @@
             "value" : "إلغاء الجرعة الأساسية المؤقتة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canceling Temp Basal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2199,6 +2295,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تغيير"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changing"
           }
         },
         "da" : {
@@ -2338,6 +2440,12 @@
             "value" : "تغيير الوقت…"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Changing time…"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2473,6 +2581,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "اختر نوع البطارية التي تستخدمها في مضختك لتحسين التنبيهات حول حالات انخفاض البطارية."
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Choose the type of battery you are using in your pump for better alerting about low battery conditions."
           }
         },
         "da" : {
@@ -2612,6 +2726,12 @@
             "value" : "ضبط"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Configuration"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2747,6 +2867,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "توصيل"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connect"
           }
         },
         "da" : {
@@ -2886,6 +3012,12 @@
             "value" : "تابع"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Continue"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3021,6 +3153,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "حذف المضخة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Pump"
           }
         },
         "da" : {
@@ -3160,6 +3298,12 @@
             "value" : "الأجهزة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Devices"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3297,6 +3441,12 @@
             "value" : "لا تستخدم MySentry"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do not use MySentry"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3431,6 +3581,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تمّ"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Done"
           }
         },
         "da" : {
@@ -3570,6 +3726,12 @@
             "value" : "خطأ في الاستئناف"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Resuming"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3702,6 +3864,12 @@
       "comment" : "The alert title for a suspend error",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Suspending"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Error Suspending"
@@ -3844,6 +4012,12 @@
             "value" : "خطأ في مزامنة الوقت"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error Syncing Time"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3979,6 +4153,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "جارٍ جلب الجلوكوز…"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching glucose…"
           }
         },
         "da" : {
@@ -4118,6 +4298,12 @@
             "value" : "جارٍ جلب التاريخ…"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching history…"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4253,6 +4439,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "جاري جلب نموذج المضخة…"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Fetching pump model…"
           }
         },
         "da" : {
@@ -4392,6 +4584,12 @@
             "value" : "إصدار البرنامج الثابت"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Firmware Version"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4527,6 +4725,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الأنسولين\nمعلق"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
           }
         },
         "da" : {
@@ -4666,6 +4870,12 @@
             "value" : "توصيل الأنسولين"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Delivery"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4801,6 +5011,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "يمكن تحديد تسليم الأنسولين من المضخة إما عن طريق تفسير تاريخ الأحداث أو مقارنة حجم الخزان مع مرور الوقت. قراءة تاريخ الأحداث توفر رسمًا بيانيًا أكثر دقة للحالة وتحديث بيانات العلاج إلى Nightscout، ولكنها تؤدي إلى استنزاف أسرع لبطارية المضخة وإمكانية حدوث معدل أخطاء راديو أعلى مقارنةً بقراءة حجم الخزان فقط. إذا لم يكن بالإمكان استخدام المصدر المحدد لأي سبب كان، سيحاول النظام العودة إلى الخيار الآخر."
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin delivery can be determined from the pump by either interpreting the event history or comparing the reservoir volume over time. Reading event history allows for a more accurate status graph and uploading up-to-date treatment data to Nightscout, at the cost of faster pump battery drain and the possibility of a higher radio error rate compared to reading only reservoir volume. If the selected source cannot be used for any reason, the system will attempt to fall back to the other option."
           }
         },
         "da" : {
@@ -4940,6 +5156,12 @@
             "value" : "الأنسولين المتبقي"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Remaining"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5077,6 +5299,12 @@
             "value" : "نوع الإنسولين"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5211,6 +5439,12 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Medtronic %1$@"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Medtronic %1$@"
           }
         },
@@ -5351,6 +5585,12 @@
             "value" : "تتمتع مضخات Medtronic من الطرازات 523 و723 و554 و754 بميزة تُدعى \"MySentry\" التي تقوم بشكل دوري ببث مستويات الخزان والبطارية للمضخة. الاستماع لهذه البثوث يسمح لنظام Loop بالتواصل مع المضخة بشكل أقل تكرارًا، مما يمكن أن يزيد من عمر بطارية المضخة. ومع ذلك، عند استخدام هذه الميزة، تظل RileyLink متيقظة لفترات أطول وتستخدم المزيد من بطاريتها الخاصة. تفعيل هذه الميزة قد يطيل عمر بطارية المضخة، بينما تعطيلها قد يطيل عمر بطارية RileyLink. يتم تجاهل هذا الإعداد بالنسبة لطرازات المضخات الأخرى."
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Medtronic pump models 523, 723, 554, and 754 have a feature called 'MySentry' that periodically broadcasts the reservoir and pump battery levels.  Listening for these broadcasts allows Loop to communicate with the pump less frequently, which can increase pump battery life.  However, when using this feature the RileyLink stays awake more of the time and uses more of its own battery.  Enabling this may lengthen pump battery life, while disabling it may lengthen RileyLink battery life. This setting is ignored for other pump models."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5486,6 +5726,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "لا"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
           }
         },
         "da" : {
@@ -5625,6 +5871,12 @@
             "value" : "لا يوجد استجابة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No response"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5760,6 +6012,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "لا، إبقاء المضخة كما هي"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
           }
         },
         "da" : {
@@ -5899,6 +6157,12 @@
             "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6003,8 +6267,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "On your pump, go to the Find Device screen and select \"Find Device\".\n\nMain Menu >\nUtilities >\nConnect Devices >\nOther Devices >\nOn >\nFind Device"
+            "state" : "translated",
+            "value" : "На помпі перейдіть на екран «Знайти пристрій» і виберіть «Знайти пристрій».\n\nГоловне меню >\nУтиліти >\nПідключення пристроїв >\nІнші пристрої >\nУвімкнено >\nЗнайти пристрій"
           }
         },
         "vi" : {
@@ -6034,6 +6298,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "مصدر البيانات المفضل"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Preferred Data Source"
           }
         },
         "da" : {
@@ -6173,6 +6443,12 @@
             "value" : "الوقت المتبقي لبطارية المضخة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Remaining"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6308,6 +6584,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نوع بطارية المضخة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Battery Type"
           }
         },
         "da" : {
@@ -6447,6 +6729,12 @@
             "value" : "ID المضخة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump ID"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6582,6 +6870,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "وقت المضخة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump Time"
           }
         },
         "da" : {
@@ -6721,6 +7015,12 @@
             "value" : "قراءة جدول الجرعة الأساسية…"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reading basal schedule…"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6856,6 +7156,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "قراءة حالة المضخة…"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reading pump status…"
           }
         },
         "da" : {
@@ -6995,6 +7301,12 @@
             "value" : "المنطقة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Region"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7130,6 +7442,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "استئناف الضخ"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume Delivery"
           }
         },
         "da" : {
@@ -7269,6 +7587,12 @@
             "value" : "استئناف"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resuming"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7404,6 +7728,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "أعد المحاولة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Retry"
           }
         },
         "da" : {
@@ -7543,6 +7873,12 @@
             "value" : "الجرعة الأساسية المجدولة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scheduled Basal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7678,6 +8014,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "حدد نوع الأنسولين الذي ستستخدمه في هذه المضخة."
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
           }
         },
         "da" : {
@@ -7817,6 +8159,12 @@
             "value" : "الضغط على زر الإرسال…"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sending button press…"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7954,6 +8302,12 @@
             "value" : "بدء الجرعة الأساسية المؤقتة"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Starting Temp Basal"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8086,6 +8440,12 @@
       "comment" : "A message indicating a command succeeded",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Succeeded"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Succeeded"
@@ -8228,6 +8588,12 @@
             "value" : "إيقاف التوصيل مؤقتًا"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend Delivery"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8365,6 +8731,12 @@
             "value" : "معلق: %1$@\n"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspended: %1$@\n"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8469,8 +8841,8 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Suspended: %1$@\n"
+            "state" : "translated",
+            "value" : "Призупинено: %1$@ "
           }
         },
         "vi" : {
@@ -8500,6 +8872,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تعليق"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspending"
           }
         },
         "da" : {
@@ -8639,6 +9017,12 @@
             "value" : "المزامنة مع الوقت الحالي"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Sync to Current Time"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8774,6 +9158,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الوقت في مضختك مختلف عن الوقت الحالي. هل ترغب في تحديث الوقت في مضختك ليتوافق مع الوقت الحالي؟"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
         "da" : {
@@ -8913,6 +9303,12 @@
             "value" : "تم اكتشاف تغيير في الوقت"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Time Change Detected"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9048,6 +9444,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تجارب"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Trials"
           }
         },
         "da" : {
@@ -9187,6 +9589,12 @@
             "value" : "ضبط الراديو…"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tuning radio…"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9322,6 +9730,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "وحدة لكل ساعة"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hr"
           }
         },
         "da" : {
@@ -9461,6 +9875,12 @@
             "value" : "غير معروف"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "unknown"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9593,6 +10013,12 @@
       "comment" : "Text shown in basal rate space when delivery status is unknown",
       "localizations" : {
         "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown"
+          }
+        },
+        "ce" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "Unknown"
@@ -9735,6 +10161,12 @@
             "value" : "استخدام MySentry"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Use MySentry"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9872,6 +10304,12 @@
             "value" : "نعم"
           }
         },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10007,6 +10445,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نعم، المزامنة مع الوقت الحالي"
+          }
+        },
+        "ce" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
           }
         },
         "da" : {

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,7 @@
+files:
+  - source: /MinimedKit/Resources/Localizable.xcstrings
+    translation: /MinimedKit/Resources/Localizable.xcstrings
+    multilingual: 1
+  - source: /MinimedKitUI/Resources/Localizable.xcstrings
+    translation: /MinimedKitUI/Resources/Localizable.xcstrings
+    multilingual: 1


### PR DESCRIPTION
Swedish and Dutch 100% and other languages not fully completed.   Created with Crowdin (= no parsing errors). 

Unfortunately there is also be an added configuration file, crowdin.yml. This file is only used by Crowdin, meaning it will not mess anything up with lokalise or the Loop Workspace. You can ignore it, when merging, but it would be easier to keep it (for future PRs).